### PR TITLE
fix(skills): forge bodies via --body-file, never hand-escaped Markdown

### DIFF
--- a/CHANGELOG.es.md
+++ b/CHANGELOG.es.md
@@ -102,6 +102,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 #### `ship-roadmap`
 | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|
+| 1.9.0 | 2026-07-04 | minor | Las issues del barrido + PRs de subagentes + comentarios de triaje usan `--body-file` (Markdown), nunca `--body`/heredoc inline; guardrail añadido. |
 | 1.8.1 | 2026-07-04 | parche | Sin cambio de comportamiento: el frontmatter `model:`/`effort:` de esta skill se trasladó a `docs/workflow/model-routing.yml` (usado solo para construir la rama `#claude`); la guía sobre modelos no-Claude en la descripción se sustituyó por un puntero a `#claude`. |
 | 1.8.0 | 2026-07-04 | menor | Barrido de issues tras la última feature: inventaría issues abiertas + el residuo documentado del propio run (known-issues, trade-offs, hallazgos pospuestos), lo triagea todo y entrega las issues fix-now por las mismas etapas — `SHIP: COMPLETE` exige el barrido; check de cierre limpio (ninguna etapa termina con árbol sucio o commits sin push); AUDIT imprime la URL del PR junto al veredicto. |
 | 1.7.0 | 2026-07-03 | menor | La etapa PR no está completa hasta que la fila del roadmap lleva su número de PR enlazado y la URL se imprime en la salida de la iteración. |
@@ -117,6 +118,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 #### `execute-phase`
 | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|
+| 1.11.0 | 2026-07-04 | minor | Los cuerpos de PR/issue se pasan con `--body-file` (fichero Markdown), nunca `--body`/heredoc inline — arregla los backticks escapados con `\` literales en issues/PRs generados; casilla 4 del contrato de turno + regla en Issue policy; comandos actualizados. |
 | 1.10.1 | 2026-07-04 | parche | Sin cambio de comportamiento: el frontmatter `model:`/`effort:` de esta skill se trasladó a `docs/workflow/model-routing.yml` (usado solo para construir la rama `#claude`); la guía sobre modelos no-Claude en la descripción se sustituyó por un puntero a `#claude`. |
 | 1.10.0 | 2026-07-04 | menor | Casilla de árbol limpio en el contrato de turno (`git status --porcelain` pegado antes de terminar; las docs cuentan); política de push en dos regímenes (con el PR abierto, cada commit se pushea inmediatamente); ciclo explícito para plegar hallazgos de review/audit (gate → commit → push → árbol limpio, o el plegado no ocurrió); las docs viajan en el commit de la fase. |
 | 1.9.0 | 2026-07-03 | menor | Cierre de PR explícito: imprimir la URL del PR en el chat (no todos los agentes muestran PRs abiertas) y registrar `done · #<pr>` (enlazado) en la fila del roadmap/índice de fixes con un commit `docs: link PR` — una fila done sin su enlace de PR es una unidad sin terminar. |
@@ -166,6 +168,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 #### `review-change`
 | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|
+| 1.9.0 | 2026-07-04 | minor | Guardrail: los cuerpos del forge creados vía triage-issue son Markdown — no pre-escapes el texto de los hallazgos; los cuerpos van por `--body-file`, nunca inline. |
 | 1.8.1 | 2026-07-04 | parche | Sin cambio de comportamiento: el frontmatter `model:`/`effort:` de esta skill se trasladó a `docs/workflow/model-routing.yml` (usado solo para construir la rama `#claude`); la guía sobre modelos no-Claude en la descripción se sustituyó por un puntero a `#claude`. |
 | 1.8.0 | 2026-07-04 | menor | El check de disciplina del workflow también verifica la higiene git: un árbol sucio (docs incluidas) o commits sin push a un PR abierto son hallazgos `workflow` fix-now; la ruta de plegado dice commit Y push antes de re-revisar. |
 | 1.7.0 | 2026-07-03 | menor | Check mecánico de disciplina del workflow en cada revisión (eje `workflow`): formato de commits, etiquetas de fase, docs por fase, sin commits en la rama por defecto, idioma de artefactos. |
@@ -230,6 +233,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 #### `triage-issue`
 | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|
+| 1.7.0 | 2026-07-04 | minor | Los comentarios datados en issues se postean con `gh issue comment --body-file` (Markdown), nunca `--body` inline — arregla los backticks escapados con `\` literales en comentarios. |
 | 1.6.1 | 2026-07-04 | parche | Sin cambio de comportamiento: el frontmatter `model:`/`effort:` de esta skill se trasladó a `docs/workflow/model-routing.yml` (usado solo para construir la rama `#claude`); la guía sobre modelos no-Claude en la descripción se sustituyó por un puntero a `#claude`. |
 | 1.6.0 | 2026-07-03 | menor | Casilla de precedencia de idioma de artefactos añadida al contrato de turno (incluye comentarios de issues). |
 | 1.5.0 | 2026-07-03 | menor | Contrato de turno al inicio (veredicto fijo por issue; nada diferido implementado; → Next: impreso al final). |
@@ -269,6 +273,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 | | 1.2.0 | 2026-07-02 | menor | Reporte de cierre fijo devuelto al router (veredicto, huecos cerrados, Closes #N enlazado) |
 | 1.1.0 | 2026-06-09 | menor | Produce un SPEC acotado **dimensionado** con `Closes #N` |
 | | 1.0.0 | 2026-06-05 | — | Issue → SPEC acotado |
+| `plan-feature-scaffold` | 1.4.0 | 2026-07-04 | menor | La tarea de cierre del TASKS.md generado ahora dice `gh pr create --body-file <path>` (fichero Markdown), nunca `--body`/heredoc inline — para que los ejecutores no emitan backticks escapados con `\` literales en el cuerpo del PR. |
 | `plan-feature-scaffold` | 1.3.1 | 2026-07-04 | parche | Sin cambio de comportamiento: el frontmatter `model:`/`effort:` de esta skill se trasladó a `docs/workflow/model-routing.yml` (usado solo para construir la rama `#claude`). |
 | | 1.3.0 | 2026-07-03 | menor | La fase final del TASKS.md generado termina con tareas literales de cierre: abrir PR + imprimir URL en el chat, enlazar la fila del roadmap, commitear y pushear el enlace. |
 | 1.2.0 | 2026-07-02 | menor | Reporte de cierre fijo (artefactos escritos, registro en roadmap, nº de fases, preguntas abiertas) |
@@ -298,6 +303,21 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 
 ## Registro cronológico (más reciente primero)
 
+- **2026-07-04 — los cuerpos del forge son Markdown, no shell.** Evidencia de
+  campo (gtrabanco/webs#198): issues/PRs/comentarios generados llegaban con
+  `` \`code\` `` literal — el agente escapaba los backticks a mano y luego pasaba
+  el cuerpo por un heredoc entre comillas / comillas simples, donde el `\`
+  sobrevive hasta el Markdown renderizado. Arreglado en la fuente en cada skill
+  que escribe en el forge: el cuerpo se escribe a un fichero y se pasa con
+  **`--body-file`**, nunca un `--body "…"`/heredoc inline, con verificación tras
+  crear. `execute-phase` 1.11.0 (PRs + issues de `--fix` + casilla del contrato
+  de turno), `triage-issue` 1.7.0 (comentarios datados), `ship-roadmap` 1.9.0
+  (issues del barrido + guardrail), `review-change` 1.9.0 (no pre-escapar el
+  texto de los hallazgos), `plan-feature-scaffold` 1.4.0 (tarea de cierre del
+  TASKS generado). La regla también se siembra en las Workflow conventions de la
+  plantilla (`template/CLAUDE.md`) para que todo proyecto que la adopte la
+  herede. Peor en unos agentes que en otros — de ahí la regla explícita en
+  formato checklist.
 - **2026-07-04 — v3: la rama por defecto pasa a ser agnóstica de modelo.**
   Cambio incompatible de distribución. `main` (instalación por defecto, sin
   `#ref`) es ahora lo que antes era `#inheritance`: ninguna skill lleva

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ How pinning actually works, verified against the `skills` CLI:
 #### `ship-roadmap`
 | Version | Date | Type | What changed |
 |---|---|---|---|
+| 1.9.0 | 2026-07-04 | minor | Sweep issues + subagent PRs + triage comments use `--body-file` (Markdown), never inline `--body`/heredoc; guardrail added. |
 | 1.8.1 | 2026-07-04 | patch | No behavior change: this skill's `model:`/`effort:` frontmatter moved to `docs/workflow/model-routing.yml` (used only to build the `#claude` branch); the description's non-Claude guidance was replaced with a pointer to `#claude`. |
 | 1.8.0 | 2026-07-04 | minor | Issue sweep after the last feature: inventory open issues + the run's documented residue (known-issues, trade-offs, postponed findings), triage everything, ship fix-now issues through the same stages — `SHIP: COMPLETE` requires the sweep; clean close-out check (no stage ends with a dirty tree or unpushed commits); AUDIT prints the PR URL next to the verdict. |
 | 1.7.0 | 2026-07-03 | minor | PR stage is not complete until the roadmap row carries its linked PR number and the URL is printed in the iteration output. |
@@ -115,6 +116,7 @@ How pinning actually works, verified against the `skills` CLI:
 #### `execute-phase`
 | Version | Date | Type | What changed |
 |---|---|---|---|
+| 1.11.0 | 2026-07-04 | minor | PR/issue bodies passed with `--body-file` (Markdown file), never inline `--body`/heredoc — fixes literal `\`-escaped backticks in generated issues/PRs; turn-contract box 4 + Issue policy rule; commands updated. |
 | 1.10.1 | 2026-07-04 | patch | No behavior change: this skill's `model:`/`effort:` frontmatter moved to `docs/workflow/model-routing.yml` (used only to build the `#claude` branch); the description's non-Claude guidance was replaced with a pointer to `#claude`. |
 | 1.10.0 | 2026-07-04 | minor | Clean-tree turn-contract box (`git status --porcelain` pasted before ending; docs count); two-regime push policy (after the PR exists, every commit pushes immediately); explicit fold cycle for review/audit findings (gate → commit → push → clean tree, or the fold didn't happen); docs must ride the phase commit. |
 | 1.9.0 | 2026-07-03 | minor | PR close-out made explicit: print the PR URL in the chat (not every agent shows open PRs) and record `done · #<pr>` (linked) on the roadmap/fix-index row via a `docs: link PR` commit — a done row without its PR link is an unfinished unit. |
@@ -164,6 +166,7 @@ How pinning actually works, verified against the `skills` CLI:
 #### `review-change`
 | Version | Date | Type | What changed |
 |---|---|---|---|
+| 1.9.0 | 2026-07-04 | minor | Guardrail: forge bodies filed via triage-issue are Markdown — don't pre-escape finding text; bodies go through `--body-file`, never inline. |
 | 1.8.1 | 2026-07-04 | patch | No behavior change: this skill's `model:`/`effort:` frontmatter moved to `docs/workflow/model-routing.yml` (used only to build the `#claude` branch); the description's non-Claude guidance was replaced with a pointer to `#claude`. |
 | 1.8.0 | 2026-07-04 | minor | Workflow-discipline check also verifies git hygiene: a dirty tree (docs included) or commits unpushed to an open PR are fix-now `workflow` findings; the fold route says commit AND push before re-review. |
 | 1.7.0 | 2026-07-03 | minor | Mechanical workflow-discipline check at every review (axis `workflow`): commit format, phase labels, per-phase docs, no default-branch commits, artifact language. |
@@ -228,6 +231,7 @@ How pinning actually works, verified against the `skills` CLI:
 #### `triage-issue`
 | Version | Date | Type | What changed |
 |---|---|---|---|
+| 1.7.0 | 2026-07-04 | minor | Dated issue comments posted with `gh issue comment --body-file` (Markdown), never inline `--body` — fixes literal `\`-escaped backticks in comments. |
 | 1.6.1 | 2026-07-04 | patch | No behavior change: this skill's `model:`/`effort:` frontmatter moved to `docs/workflow/model-routing.yml` (used only to build the `#claude` branch); the description's non-Claude guidance was replaced with a pointer to `#claude`. |
 | 1.6.0 | 2026-07-03 | minor | Artifact-language precedence box added to the turn contract (issue comments included). |
 | 1.5.0 | 2026-07-03 | minor | Turn contract at the top (per-issue fixed verdict; nothing deferred implemented; → Next: printed last). |
@@ -267,6 +271,7 @@ How pinning actually works, verified against the `skills` CLI:
 | | 1.2.0 | 2026-07-02 | minor | Fixed completion report returned to the router (verdict, gaps closed, Closes #N wired) |
 | 1.1.0 | 2026-06-09 | minor | Produces a **sized** scoped SPEC with `Closes #N` |
 | | 1.0.0 | 2026-06-05 | — | Issue → scoped SPEC |
+| `plan-feature-scaffold` | 1.4.0 | 2026-07-04 | minor | Generated TASKS.md close-out task now says `gh pr create --body-file <path>` (Markdown file), never inline `--body`/heredoc — so executors don't emit literal `\`-escaped backticks in the PR body. |
 | `plan-feature-scaffold` | 1.3.1 | 2026-07-04 | patch | No behavior change: this skill's `model:`/`effort:` frontmatter moved to `docs/workflow/model-routing.yml` (used only to build the `#claude` branch). |
 | | 1.3.0 | 2026-07-03 | minor | Generated TASKS.md final phase ends with literal close-out tasks: open PR + print URL in chat, link the roadmap row, commit & push the link. |
 | 1.2.0 | 2026-07-02 | minor | Fixed completion report (artifacts written, roadmap registration, phase count, open questions) |
@@ -296,6 +301,20 @@ How pinning actually works, verified against the `skills` CLI:
 
 ## Release log (chronological, newest first)
 
+- **2026-07-04 — forge bodies are Markdown, not shell.** Field evidence
+  (gtrabanco/webs#198): generated issues/PRs/comments arrived with literal
+  `` \`code\` `` — the agent hand-escaped backticks, then passed the body through
+  a quoted heredoc / single quotes where the `\` survives into the rendered
+  Markdown. Fixed at the source across every skill that writes to the forge:
+  the body is written to a file and passed with **`--body-file`**, never an
+  inline `--body "…"`/heredoc, with a post-create verification. `execute-phase`
+  1.11.0 (PRs + `--fix` issues + turn-contract box), `triage-issue` 1.7.0
+  (dated comments), `ship-roadmap` 1.9.0 (sweep issues + guardrail),
+  `review-change` 1.9.0 (don't pre-escape finding text), `plan-feature-scaffold`
+  1.4.0 (generated TASKS close-out task). The rule is also seeded into the
+  template's Workflow conventions (`template/CLAUDE.md`) so every adopting
+  project inherits it. Worse on some agents than others — hence the explicit,
+  checklist-style rule.
 - **2026-07-04 — v3: the default branch becomes model-agnostic.** Breaking
   distribution change. `main` (default install, no `#ref`) is now what used
   to be `#inheritance`: no skill carries `model:`/`effort:` frontmatter, so

--- a/skills/execute-phase/SKILL.md
+++ b/skills/execute-phase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: execute-phase
 user-invocable: true
-version: 1.10.1
+version: 1.11.0
 argument-hint: <NN> <phase> | <NN> (single-pass) | --fix | [--force]
 allowed-tools: [Bash, Read, Edit, Write, MultiEdit]
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
@@ -37,7 +37,8 @@ Three modes:
      `gh pr create` were EXECUTED and **the PR URL is printed in the chat**
      (not every agent shows open PRs — the link in the chat is the contract).
      The PR body is NEVER empty: what it does, why, evidence, and
-     `Closes #<n>` when issue-born. AND the roadmap row (or fix-index entry)
+     `Closes #<n>` when issue-born. The body is passed with `--body-file`
+     (real Markdown, NO `\`-escaped backticks — see Issue policy). AND the roadmap row (or fix-index entry)
      was updated to `done · [#<pr>](<pr-url>)` in a follow-up
      `docs: link PR #<n>` commit, pushed to the same branch. A `done` row
      without its PR link is an UNFINISHED unit. Unit not finished? Then
@@ -177,7 +178,23 @@ checkout — and then one worktree per unit, removed after merge.
 Forge operations use the project's declared forge CLI (Workflow conventions —
 examples use `gh`; translate if the project declares another forge).
 
-- **`--fix`:** every fix needs a tracked issue; create with `gh issue create --template fix.yml` if missing, populating the body from the SPEC. Use the returned number for branch and folder.
+> **Forge bodies are Markdown, not shell — never hand-escape them.** Backticks,
+> `*`, `_`, `#`, `|` in an issue / PR / comment body are **formatting**; a `\`
+> before them renders **literally** (`` \`code\` `` instead of `` `code` ``) —
+> the #1 forge-formatting bug (worse on some agents than others). Fix it at the
+> source: **never pass a Markdown body inline** (`--body "…"`, a quoted
+> `<<'EOF'` heredoc, or single quotes — all of these preserve a stray `\` or
+> mangle backticks). Instead **write the body to a file with the Write tool**
+> (plain Markdown — real backticks, zero backslashes; scratchpad is fine) and
+> pass **`--body-file <path>`**: `gh issue create --body-file <path>`,
+> `gh pr create --body-file <path>`, `gh issue comment <n> --body-file <path>`
+> (or the declared forge's equivalent). Short one-liners with no Markdown (e.g.
+> a bare `Closes #12`) may stay inline. **Verify after creating:**
+> `gh issue view <n> --json body` / `gh pr view <n> --json body` must show
+> backticks rendering — a literal `` \` `` in the output means redo it with
+> `--body-file`.
+
+- **`--fix`:** every fix needs a tracked issue; create with `gh issue create --template fix.yml --body-file <path>` if missing, populating the body from the SPEC (body as a Markdown file — see the Markdown rule above). Use the returned number for branch and folder.
 - **feature:** if it came from an issue, include `Closes #<n>` in the PR body. Don't create issues for features that didn't originate from one.
 - **Language precedence for every artifact** (issues, PRs, commits, SPECs, docs): (1) an explicit user instruction in the prompt, else (2) the project's declared docs language (Workflow conventions), else (3) English. The conversation language is NOT a signal — being asked in Spanish never makes the PR Spanish. Non-matching source material gets translated first.
 
@@ -213,9 +230,10 @@ examples use `gh`; translate if the project declares another forge).
 6. Stage and commit: `git add <changed files>` then `git commit -m "<type>(<scope>): <summary>"`.
 7. **Mark done + open the PR — always (this is the last step).** Flip the roadmap
    row to `done` (it's *built*; merge state lives in the forge, not the status —
-   see *Marking done*), commit that flip, then `git push` and open the PR:
-   `gh pr create --base main --title "<type>(<scope>): <summary>" --body "<summary>"`
-   (add `Closes #<n>` when issue-born). Then, with the URL `gh pr create`
+   see *Marking done*), commit that flip, then `git push` and open the PR
+   (body written to a file as Markdown, per the Markdown rule above):
+   `gh pr create --base main --title "<type>(<scope>): <summary>" --body-file <path>`
+   (put `Closes #<n>` in that body when issue-born). Then, with the URL `gh pr create`
    returned: **print it in the chat**, update the roadmap row to
    `done · [#<pr>](<pr-url>)`, commit (`docs: link PR #<n>`), and push again —
    the link commit rides the same open PR. A single-pass unit **never ends
@@ -227,7 +245,8 @@ examples use `gh`; translate if the project declares another forge).
 **`--fix`** — `docs/fix/<n>-<topic>/`, template `docs/fix/_TEMPLATE/SPEC.md`, index `docs/fix/README.md`:
 
 1. Verify the issue exists (`gh issue view <n>`); if it doesn't, create it
-   (`gh issue create --template fix.yml`, body from the SPEC).
+   (`gh issue create --template fix.yml --body-file <path>`, body from the SPEC
+   written to a Markdown file — per the Markdown rule above).
 2. **If `docs/fix/<n>-<topic>/SPEC.md` already exists (e.g. from `plan-fix`), use it — do not re-draft.** Otherwise copy the template, fill every section, and register the entry in `docs/fix/README.md`.
 3. Verify branch (`fix/<n>-<topic>`).
 4. Implement the fix (no planning artifacts; the SPEC is enough).
@@ -235,8 +254,9 @@ examples use `gh`; translate if the project declares another forge).
 6. Stage and commit: `git add <changed files>` then `git commit -m "fix(<scope>): <summary>"`.
 7. **Mark done + open the PR — always (this is the last step).** Set the
    `docs/fix/README.md` entry's status to `done` (built, not yet merged), commit,
-   `git push`, then open the PR: `gh pr create --base main --title "fix(<scope>): <summary>" --body "Closes #<n>"`.
-   Run the commands. Then, with the returned URL: **print it in the chat**,
+   `git push`, then open the PR with the body written to a Markdown file (per the
+   Markdown rule above): `gh pr create --base main --title "fix(<scope>): <summary>" --body-file <path>`
+   (the body includes `Closes #<n>`). Run the commands. Then, with the returned URL: **print it in the chat**,
    set the `docs/fix/README.md` entry to `done · [#<pr>](<pr-url>)`, commit
    (`docs: link PR #<n>`), and push again. A fix **never ends branch-only** —
    it always leaves an open, chat-linked PR.

--- a/skills/plan-feature-scaffold/SKILL.md
+++ b/skills/plan-feature-scaffold/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan-feature-scaffold
 user-invocable: false
-version: 1.3.1
+version: 1.4.0
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
 description: >
@@ -61,8 +61,10 @@ the agent guide and state the assumption.
        documented.
      - `TASKS.md` — per-phase checklists the executor ticks off. **The final
        phase's checklist always ends with these literal close-out tasks**:
-       "[ ] open the PR (`gh pr create` with full body) and PRINT THE PR URL
-       in the chat", "[ ] update the roadmap row to `done · [#<pr>](<pr-url>)`",
+       "[ ] open the PR (`gh pr create --body-file <path>` — body written as a
+       Markdown file, real backticks, never inline `--body`/heredoc that leaves
+       `\`-escaped backticks) and PRINT THE PR URL in the chat",
+       "[ ] update the roadmap row to `done · [#<pr>](<pr-url>)`",
        "[ ] commit `docs: link PR #<n>` and push" — so the close-out is a
        ticked task, not an assumed behavior.
      - `progress.md` — running log, one entry per phase.

--- a/skills/review-change/SKILL.md
+++ b/skills/review-change/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-change
 user-invocable: true
-version: 1.8.1
+version: 1.9.0
 argument-hint: <path-or-glob>
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
@@ -203,6 +203,12 @@ disposition is a decision, not a default:
   CLI/lib/infra). Always report what was skipped and why.
 - Honor the project's **Workflow conventions** (docs-language, evidence): cite
   `file:line`, mark uncertainties *verify*.
+- **Any forge body this review causes (issues/comments filed via `triage-issue`)
+  is Markdown, not shell — never hand-escape.** A `\` before a backtick/`*`/`_`
+  renders literally (`` \`code\` `` instead of `` `code` ``); bodies go through
+  `--body-file <path>`, never an inline `--body "…"`/heredoc. `triage-issue`
+  enforces this for the comments it posts — don't undercut it by pre-escaping
+  finding text you hand it.
 
 ## Portability (agents other than Claude Code)
 

--- a/skills/ship-roadmap/SKILL.md
+++ b/skills/ship-roadmap/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ship-roadmap
 user-invocable: true
-version: 1.8.1
+version: 1.9.0
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
 argument-hint: "[--fullauto] | --continue [--fullauto]"
@@ -216,8 +216,10 @@ turns:
          trade-offs in `decisions.md`, and every review report's
          postponed/intentional-tradeoff findings. For residue items that are
          real defects/gaps but have no tracked issue yet, **file the issue
-         now** (forge CLI; body cites the doc + trigger). Log the full
-         inventory (issue #s + sources) to the run log.
+         now** (forge CLI; body cites the doc + trigger). **The issue body is
+         Markdown — write it to a file and pass `--body-file`, never an inline
+         `--body "…"`/heredoc that leaves `\`-escaped backticks** (see
+         Guardrails). Log the full inventory (issue #s + sources) to the run log.
       2. **TRIAGE (compose `triage-issue` in-turn, equal tier).** Classify
          each inventoried issue against the CURRENT codebase. fix-now → it
          becomes a selectable unit; postpone / wontfix / promote-to-feature →
@@ -406,6 +408,15 @@ Closing line, verbatim policy: **this report recommends; the human decides.**
 - **Never work on the default branch** — the empty-repo initial scaffold commit
   is the single exception. One PR per unit, never stacked; roadmap status flips
   ride PR-bound commits only.
+- **Forge bodies are Markdown, not shell — never hand-escape.** Every issue,
+  PR, or comment the run creates (the sweep's issues, subagent PRs, triage
+  comments) carries a body of **real Markdown**: backticks / `*` / `_` are
+  formatting, and a `\` before them renders literally (`` \`code\` `` instead
+  of `` `code` ``). Write the body to a file and pass **`--body-file <path>`**
+  to `gh issue create` / `gh pr create` / `gh issue comment` (or the declared
+  forge's equivalent) — never inline `--body "…"` or a quoted heredoc. Verify
+  with `gh … --json body` that no literal `` \` `` survived. (execute-phase
+  subagents already follow this; the conductor must too for the sweep.)
 - **Never commit red; never merge red.** The gate and the floors are
   unconditional — no flag, mode, or interview answer disables them.
 - **No stage ends dirty or unpushed.** The clean close-out check (Mode B

--- a/skills/triage-issue/SKILL.md
+++ b/skills/triage-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: triage-issue
 user-invocable: true
-version: 1.6.1
+version: 1.7.0
 argument-hint: <issue-number> [more issue numbers…]
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
@@ -79,7 +79,15 @@ gh issue view <N> --json number,title,body,labels,state,comments
    judgment rather than evidence, present the verdict and options and let the
    user choose before acting.
 5. **Report and keep docs coherent.** Post the decision as a dated issue comment
-   with evidence. If it becomes an active fix, register it in the fix index; if
+   with evidence. **The comment is Markdown, not shell — never hand-escape it:**
+   backticks / `*` / `_` in the body are formatting; a `\` before them renders
+   literally (`` \`code\` `` instead of `` `code` ``). Write the comment body to
+   a file with the Write tool (plain Markdown, real backticks, zero backslashes)
+   and post it with **`gh issue comment <n> --body-file <path>`** (or the
+   declared forge's equivalent) — never an inline `--body "…"` or a quoted
+   heredoc, which mangle backticks. After posting, `gh issue view <n> --json
+   comments` must show the backticks rendering, no literal `` \` ``. If it
+   becomes an active fix, register it in the fix index; if
    closed, remove any stale index entry. Never mutate GitHub state (labels,
    close) without confirmation when ambiguous.
 6. **Return exactly, per issue** (fixed verdict format — batch runs repeat it,

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -51,6 +51,19 @@ CLI the skills use for issues and PRs. Skill examples are written with `gh`; whe
 this project declares a different forge, run the equivalent command with its CLI.
 The auto-close convention (`Closes #N` in the PR/MR body) must hold either way.
 
+**Forge bodies are Markdown, not shell — never hand-escape them.** An issue, PR,
+or comment body renders as Markdown: backticks, `*`, `_`, `#`, `|` are
+formatting, **not** shell syntax, so **never put a `\` before them**. A stray
+`\` renders literally (`` \`code\` `` instead of `` `code` ``) — the most common
+forge-formatting bug. Always **write the body to a file** (plain Markdown, real
+backticks, zero backslashes) and pass **`--body-file <path>`**
+(`gh issue create --body-file`, `gh pr create --body-file`,
+`gh issue comment --body-file`, or the forge's equivalent) — **never** an inline
+`--body "…"` or a quoted `<<'EOF'` heredoc, both of which mangle backticks or
+preserve the stray `\`. A bare non-Markdown one-liner (e.g. `Closes #12`) may
+stay inline. Verify after: `gh issue view <n> --json body` shows backticks
+rendering, no literal `` \` ``.
+
 **Git workflow:** `<branches | worktrees>` — how parallel work is handled.
 **`branches`** (default): plain feature/fix branches via `git switch -c`, **one
 active unit at a time**, sequential — slower, but the working tree is always the


### PR DESCRIPTION
## The bug

Generated issues, PRs and comments arrive with **literal backslash-escaped backticks** — `` \`code\` `` renders as text instead of formatting. Real example: gtrabanco/webs#198 (every code span in the body shows `\`computeWeeks\``, `\`apps/gruxon-web/...\``, etc.).

**Root cause:** the agent hand-escapes backticks defensively (they trigger command substitution in an unquoted/double-quoted shell string), then passes the body through a **quoted heredoc (`<<'EOF'`) or single quotes** — contexts where `\`` is *not* an escape sequence, so the `\` survives literally into the Markdown. More frequent on some agents (notably Claude) than others.

## The fix — one rule, applied everywhere a skill writes to the forge

**Forge bodies are Markdown, not shell — never hand-escape them.** Write the body to a file (plain Markdown, real backticks, zero backslashes) and pass **`--body-file <path>`**; never an inline `--body "…"` or a quoted heredoc. Verify after creating with `gh … --json body`. This eliminates the shell-quoting problem entirely rather than trying to escape correctly.

Applied to every skill that creates forge content, plus the template so adopting projects inherit it:

| Skill | Bump | Change |
|---|---|---|
| `execute-phase` | 1.10.0 → **1.11.0** | Issue-policy Markdown rule; PR + `--fix` issue commands use `--body-file`; turn-contract box 4 covers it |
| `triage-issue` | 1.6.0 → **1.7.0** | Dated comments posted with `gh issue comment --body-file` |
| `ship-roadmap` | 1.8.0 → **1.9.0** | Sweep issues + subagent PRs + triage comments; new guardrail |
| `review-change` | 1.8.0 → **1.9.0** | Guardrail: don't pre-escape finding text handed to `triage-issue` |
| `plan-feature-scaffold` | 1.3.0 → **1.4.0** | Generated `TASKS.md` close-out task now says `gh pr create --body-file` |
| `template/CLAUDE.md` | — | Rule seeded into the Workflow conventions block |

`plan-fix` and `plan-feature-from-issue` only *read* the forge (`gh issue view`), so they need no change.

## Test plan

- [x] Confirmed the broken output in gtrabanco/webs#198 via `gh issue view 198 --json body` (literal `\`` throughout)
- [x] `npx skills add . --list` discovers all 25 skills
- [x] Every touched skill references `--body-file`; remaining inline `--body "…"` occurrences are all inside the *rule text* ("never inline `--body`"), not real commands
- [x] Authoring lints (turn contract, → Next:, Portability, phase labels) pass

> Note: opened against `main`; it overlaps in the changelog/skill files with the still-open v3 PR (#2), so whichever merges second will need a trivial changelog conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)