### PR TITLE
feat(skills): measured performance review (init-workspace + review-perf)

### DIFF
--- a/CHANGELOG.es.md
+++ b/CHANGELOG.es.md
@@ -271,6 +271,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 #### `init-workspace`
 | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|
+| 1.8.0 | 2026-07-05 | menor | La entrevista gana una ronda de **Tooling de rendimiento**: checklist de detección por slot (lint de complejidad / harness de benchmarks / profiler — ejemplos del adaptador TS/JS: grupo complexity de Biome o sonarjs+unicorn, vitest bench / mitata / tinybench, `node --cpu-prof` / 0x / `bun --inspect`), instalación confirmada por el usuario y registro en el nuevo bloque `Performance commands` de la plantilla para que `review-perf` mida en vez de estimar. |
 | 1.6.0 | 2026-07-05 | menor | Envelope máquina: cada invocación termina ahora con un bloque JSON fijo (state, unit, phase, pr, findings, blockers, dependencies, next + pista de tier de modelo) para orquestación programática — esquema en la skill interna `orchestration-envelope`, protocolo en `docs/workflow/ORCHESTRATION.md`. |
 | 1.5.1 | 2026-07-04 | parche | Sin cambio de comportamiento: el frontmatter `model:`/`effort:` de esta skill se trasladó a `docs/workflow/model-routing.yml` (usado solo para construir la rama `#claude`); la guía sobre modelos no-Claude en la descripción se sustituyó por un puntero a `#claude`. |
 | 1.5.0 | 2026-07-03 | menor | Casilla de precedencia de idioma de artefactos añadida al contrato de turno; la regla Docs language de la plantilla enuncia ahora la precedencia. |
@@ -321,13 +322,24 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 | | 1.0.0 | 2026-07-02 | — | Pack de revisión interno: checklist de accesibilidad (semántica, teclado, foco, contraste, ARIA) |
 | `review-brand` | 1.0.1 | 2026-07-04 | parche | Sin cambio de comportamiento: el frontmatter `model:`/`effort:` de esta skill se trasladó a `docs/workflow/model-routing.yml` (usado solo para construir la rama `#claude`). |
 | | 1.0.0 | 2026-07-02 | — | Pack de revisión interno: checklist de marca y copy (voz, glosario, claims honestos) |
-| `review-perf` | 1.0.1 | 2026-07-04 | parche | Sin cambio de comportamiento: el frontmatter `model:`/`effort:` de esta skill se trasladó a `docs/workflow/model-routing.yml` (usado solo para construir la rama `#claude`). |
+| `review-perf` | 1.1.0 | 2026-07-05 | menor | Evidencia medida: cuando la guía del proyecto declara un bloque `Performance commands` y el diff toca rutas con benchmarks, el comando bench declarado se EJECUTA en base y cambio y se citan ambos números (`<cmd> → base <x> / change <y> (<±z%>)`); las regresiones más allá de la banda de ruido (declarada, si no ±5%) son mayores; un comando bench que falla es en sí un hallazgo. Sin comandos declarados → `n/a — no declared perf commands` explícito + hallazgo menor de adoptar tooling cuando el diff añade código algorítmico sobre input que crece. |
+| | 1.0.1 | 2026-07-04 | parche | Sin cambio de comportamiento: el frontmatter `model:`/`effort:` de esta skill se trasladó a `docs/workflow/model-routing.yml` (usado solo para construir la rama `#claude`). |
 | | 1.0.0 | 2026-07-02 | — | Pack de revisión interno: checklist de rendimiento (N+1, complejidad, fugas, peso de assets) |
 | `review-seo` | 1.0.1 | 2026-07-04 | parche | Sin cambio de comportamiento: el frontmatter `model:`/`effort:` de esta skill se trasladó a `docs/workflow/model-routing.yml` (usado solo para construir la rama `#claude`). |
 | | 1.0.0 | 2026-07-02 | — | Pack de revisión interno: checklist SEO (metadatos, canonical, indexabilidad, datos estructurados) |
 ---
 
 ## Registro cronológico (más reciente primero)
+
+- **2026-07-05 — revisión de rendimiento medida.** Los hallazgos de
+  rendimiento pasan de "plausibles" a "medidos": `init-workspace` 1.8.0
+  entrevista por el tooling de rendimiento del stack (lint de complejidad,
+  harness de benchmarks, profiler — ejemplos TS/JS nombrados, contrato
+  genérico para el resto) y registra los comandos en el nuevo bloque
+  `Performance commands` de la plantilla; `review-perf` 1.1.0 ejecuta el
+  bench declarado en base y cambio y cita ambos números, con banda de ruido
+  explícita y un `n/a — no declared perf commands` explícito cuando no hay
+  nada declarado. Feature `02-measured-perf-review`.
 
 - **2026-07-05 — `@gtrabanco/agentic-workflow-schema` 1.0.1: arreglos de
   review antes de que nadie construya sobre 1.0.0.** Una pasada de

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,6 +269,7 @@ How pinning actually works, verified against the `skills` CLI:
 #### `init-workspace`
 | Version | Date | Type | What changed |
 |---|---|---|---|
+| 1.8.0 | 2026-07-05 | minor | Interview gains a **Performance tooling** round: per-slot detection checklist (complexity lint / benchmark harness / profiler — TS/JS adapter examples: Biome complexity group or sonarjs+unicorn, vitest bench / mitata / tinybench, `node --cpu-prof` / 0x / `bun --inspect`), user-confirmed installation, and registration in the template's new `Performance commands` block so `review-perf` can measure instead of guess. |
 | 1.6.0 | 2026-07-05 | minor | Machine envelope: every invocation now ends with a fixed JSON block (state, unit, phase, pr, findings, blockers, dependencies, next + model-tier hint) for programmatic orchestration — schema in the internal `orchestration-envelope` skill, protocol in `docs/workflow/ORCHESTRATION.md`. |
 | 1.5.1 | 2026-07-04 | patch | No behavior change: this skill's `model:`/`effort:` frontmatter moved to `docs/workflow/model-routing.yml` (used only to build the `#claude` branch); the description's non-Claude guidance was replaced with a pointer to `#claude`. |
 | 1.5.0 | 2026-07-03 | minor | Artifact-language precedence box added to the turn contract; template's Docs language rule now states the precedence. |
@@ -319,13 +320,24 @@ How pinning actually works, verified against the `skills` CLI:
 | | 1.0.0 | 2026-07-02 | — | Internal review pack: accessibility checklist (semantics, keyboard, focus, contrast, ARIA) |
 | `review-brand` | 1.0.1 | 2026-07-04 | patch | No behavior change: this skill's `model:`/`effort:` frontmatter moved to `docs/workflow/model-routing.yml` (used only to build the `#claude` branch). |
 | | 1.0.0 | 2026-07-02 | — | Internal review pack: brand & copy checklist (voice, glossary, honest claims) |
-| `review-perf` | 1.0.1 | 2026-07-04 | patch | No behavior change: this skill's `model:`/`effort:` frontmatter moved to `docs/workflow/model-routing.yml` (used only to build the `#claude` branch). |
+| `review-perf` | 1.1.0 | 2026-07-05 | minor | Measured evidence: when the project's agent guide declares a `Performance commands` block and the diff touches benchmarked paths, the declared bench command is RUN on base and change and both numbers are cited (`<cmd> → base <x> / change <y> (<±z%>)`); regressions beyond the noise band (declared, else ±5%) are major; a failing bench command is itself a finding. No declared commands → explicit `n/a — no declared perf commands` + a minor adopt-tooling finding when the diff adds algorithmic code on growable input. |
+| | 1.0.1 | 2026-07-04 | patch | No behavior change: this skill's `model:`/`effort:` frontmatter moved to `docs/workflow/model-routing.yml` (used only to build the `#claude` branch). |
 | | 1.0.0 | 2026-07-02 | — | Internal review pack: performance checklist (N+1s, complexity, leaks, asset weight) |
 | `review-seo` | 1.0.1 | 2026-07-04 | patch | No behavior change: this skill's `model:`/`effort:` frontmatter moved to `docs/workflow/model-routing.yml` (used only to build the `#claude` branch). |
 | | 1.0.0 | 2026-07-02 | — | Internal review pack: SEO checklist (metadata, canonical, indexability, structured data) |
 ---
 
 ## Release log (chronological, newest first)
+
+- **2026-07-05 — measured performance review.** Perf findings graduate from
+  "plausible" to "measured": `init-workspace` 1.8.0 interviews for the
+  stack's performance tooling (complexity lint, benchmark harness, profiler —
+  TS/JS adapter examples named, generic contract for everything else) and
+  registers the commands in the template's new `Performance commands` block;
+  `review-perf` 1.1.0 runs the declared bench on base and change and cites
+  both numbers, with an explicit noise band and an explicit
+  `n/a — no declared perf commands` when nothing is declared. Feature
+  `02-measured-perf-review`.
 
 - **2026-07-05 — `@gtrabanco/agentic-workflow-schema` 1.0.1: review fixes
   before anyone builds on 1.0.0.** A `review-change` pass on the freshly

--- a/docs/features/02-measured-perf-review/CHECKLIST.md
+++ b/docs/features/02-measured-perf-review/CHECKLIST.md
@@ -1,0 +1,31 @@
+# 02 — measured-perf-review — Completion checklist (single-pass)
+
+- [x] No schema/migrations — n/a (docs-only repo)
+- [x] Core layer imports — n/a (markdown skills, no code layers)
+- [x] `init-workspace` 1.8.0: Performance tooling interview round added
+      (per-slot fixed checklist; TS/JS tools marked as adapter examples;
+      user-confirmed installation; registers the `Performance commands` block)
+- [x] `review-perf` 1.1.0: measured-evidence item (run declared bench on base
+      + change, cite both numbers, noise band ±5% default, failing command is
+      a finding) + explicit `n/a — no declared perf commands` wording + minor
+      adopt-tooling finding; report contract otherwise unchanged
+      (`PASS | FAIL` decision untouched — callers need no changes)
+- [x] `template/CLAUDE.md`: `Performance commands` block next to the
+      verification gate (bench / profile / complexity-lint / noise-band)
+- [x] Stack-agnostic rule: tool names appear only in init-workspace's marked
+      adapter list and the template block's examples — verified by grep
+      (see PR evidence)
+- [x] Gate green: `npx skills add . --list` exit 0
+- [x] CHANGELOG.md + CHANGELOG.es.md rows (init-workspace 1.8.0, review-perf
+      1.1.0) + release-log entries; README tables unchanged (no new
+      user-facing skill, counts stay)
+- [x] User-facing limitations disclosed: benchmark noise on laptops mitigated
+      by the noise band (SPEC risk R1)
+- [x] No new dependencies
+
+Decisions not in the SPEC: none — D1 (run only when declared AND relevant)
+and D2 (user-confirmed installs) implemented as specified.
+
+Version note: `init-workspace` jumps 1.6.0 → 1.8.0 on this branch because
+1.7.0 is taken by feature 01's PR #8 (Docs site round). Merge #8 first; the
+CHANGELOG row orders resolve on rebase if needed.

--- a/docs/features/02-measured-perf-review/SPEC.md
+++ b/docs/features/02-measured-perf-review/SPEC.md
@@ -1,0 +1,173 @@
+# 02 — measured-perf-review
+
+> Feature specification. Size S — this SPEC is the only planning artifact;
+> implement with `execute-phase 02` in a single pass.
+
+## Goal
+
+Make performance review **measured instead of guessed**: `init-workspace`
+discovers (and offers to install) performance tooling whenever the target
+project's stack allows it and registers the commands in the project's docs;
+`review-perf` runs those declared commands so its findings cite real numbers.
+A finding backed by a measurement beats a finding backed by reading.
+
+## Branch
+
+`feat/02-measured-perf-review`
+
+## Size
+
+`S` — surgical edits to two existing SKILL.md files plus a template block.
+
+## Dependencies
+
+None. (Independent of 01 and 03.)
+
+## Context
+
+`review-perf` v1.0.1 is a static-reading checklist: it detects structural
+antipatterns (N+1, unclosed resources, invariant recomputation) but cannot
+verify a complexity claim or a regression — and its own last checklist item
+forbids optimization "without a cited measurement", a measurement the workflow
+currently never produces. Meanwhile `init-workspace` interviews the project but
+never asks about perf tooling, so no project ends up with benchmark/profiling
+commands the reviews could run.
+
+## Business goals
+
+n/a — internal workflow quality.
+
+## Technical goals
+
+- Perf findings graduate from "plausible" to "measured" wherever the stack has
+  cheap tooling.
+- Stay stack-agnostic: the generic contract is "the project declares perf
+  commands"; concrete tools appear only in a marked adapter section
+  (TS/JS reference set, per the user's primary stack).
+
+## Scope
+
+### In scope
+
+1. **`init-workspace`**: new interview step "Performance tooling" —
+   - Detect the stack's options via a fixed checklist (first match per slot):
+     - *Static complexity lint*: Biome present → enable its `complexity` group
+       (incl. `noExcessiveCognitiveComplexity`); ESLint present → suggest
+       `eslint-plugin-sonarjs` + `eslint-plugin-unicorn`; neither → n/a.
+     - *Benchmark harness*: Vitest → `vitest bench`; Bun runtime → `mitata`;
+       Node → `tinybench`/`mitata`; other stacks → ask for the project's
+       benchmark command or record n/a.
+     - *Profiler*: Node → `node --cpu-prof` (zero-dep default) or `0x` via the
+       project's package runner; Bun → `bun --inspect` CPU profiling; other →
+       ask or n/a.
+   - Offer installation (user confirms; never silently add dependencies) and
+     **register the resulting commands** in the project's agent guide under a
+     `Performance commands` block (bench command, profile command, lint scope),
+     next to the verification gate.
+   - Template: the agent-guide template gains the (commented, optional)
+     `Performance commands` block.
+2. **`review-perf`** (minor version bump): checklist gains measured items —
+   - ✓ If the project declares a benchmark command AND the diff touches paths
+     the benchmarks cover: RUN it, paste the before/after numbers (base branch
+     vs change) in Evidence. A regression beyond noise is a major finding.
+   - ✓ If no perf commands are declared: state `n/a — no declared perf
+     commands` explicitly (never silently skip), and when the diff adds
+     algorithmic code on growable input, emit a **minor** finding recommending
+     the project adopt the tooling (points at `init-workspace`).
+   - Evidence column for measured findings carries the command + numbers, not
+     only `file:line`.
+3. `bump-skill` bookkeeping (versions, CHANGELOG EN/ES, README tables EN/ES).
+
+### Out of scope / non-goals
+
+- A separate `optimize` skill that *applies* perf fixes — review-perf stays
+  findings-only. If wanted later, plan it as its own feature.
+- Writing benchmark files for the target project — the project (or a unit of
+  work in it) owns its benches; the skills only run declared commands.
+- CI perf budgets/regression gates — target-project infra.
+- Non-TS/JS adapter sets (Python, Go…) — the generic "declare your commands"
+  contract already covers them; named recipes can be added on demand.
+
+## Architecture impact
+
+None structural: two skill bodies + one template block. Keeps the
+stack-agnostic rule: TS/JS tool names live only in the marked adapter list
+inside `init-workspace`; `review-perf` references only "the project's declared
+perf commands".
+
+## Design
+
+Fixed contract shape (closed, agent-independent):
+
+- The declaration block the skills read/write (in the target project's agent
+  guide):
+
+  ```
+  ## Performance commands
+  - bench: <command | none>
+  - profile: <command | none>
+  - complexity-lint: <command | none>
+  ```
+
+- `review-perf`'s measured-evidence format inside the existing report table:
+  `Evidence: <cmd> → base <x> / change <y> (<±z%>)`.
+- Decision rule unchanged (`PASS | FAIL` on critical/major), so callers
+  (`review-change`, `product-audit`) need no changes.
+
+## Decisions to confirm
+
+- D1 — review-perf runs benches only when declared AND relevant to the diff
+  (never unconditionally): **chosen** — keeps review cost bounded.
+- D2 — installation is always user-confirmed in init-workspace: **chosen** —
+  a scaffolding skill must not add dependencies silently.
+
+## Acceptance criteria
+
+- `init-workspace` SKILL.md contains the Performance tooling interview step
+  with the fixed per-slot detection checklist and the registration block;
+  template updated with the commented block.
+- `review-perf` SKILL.md contains the run-when-declared items with the exact
+  n/a wording and measured Evidence format; report contract otherwise
+  unchanged.
+- Both skills' `version:` bumped; CHANGELOG.md, CHANGELOG.es.md, README.md,
+  README.es.md rows updated.
+- `npx skills add . --list` still lists every skill; cross-references resolve.
+- No stack-specific names outside the marked adapter list.
+
+## Testing requirements
+
+Docs-level gate (CLAUDE.md → Verification): skills CLI discovery, markdown
+link sweep, stack-leak grep (`grep -rn "biome\|mitata\|0x\|sonarjs"` must hit
+only the marked adapter section of init-workspace).
+
+## Dev scenarios
+
+| Scenario | Reproduces | Mechanism it drives |
+|---|---|---|
+| `perf:declared-and-hit` | bench declared, diff touches covered path | dry-run the checklist on a fixture declaration → measured Evidence row |
+| `perf:not-declared` | project without perf commands | explicit `n/a — no declared perf commands` + minor adopt-tooling finding |
+| `perf:bench-fails` | declared command exits non-zero | finding (gate can't measure) routed like a red verification gate, not silently skipped |
+
+## Phases
+
+Single-pass (`execute-phase 02`) — no PLAN/TASKS. Close-out: open the PR, print
+its URL, roadmap row → done.
+
+## Deploy & rollback
+
+n/a — merging is enough.
+
+## Open questions / risks
+
+- R1: benchmark noise on laptops → mitigated by requiring the ± delta in
+  Evidence and treating <noise-band deltas as no-finding; band stated in the
+  checklist (default ±5% unless the project declares one).
+
+## Deliverables
+
+Edits to `skills/init-workspace/SKILL.md`, `skills/review-perf/SKILL.md`,
+template agent-guide block; CHANGELOGs + READMEs; this SPEC.
+
+## Post-merge next feature
+
+`03-orchestrator-crash-recovery` (independent; see ROADMAP).

--- a/skills/init-workspace/SKILL.md
+++ b/skills/init-workspace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: init-workspace
 user-invocable: true
-version: 1.6.0
+version: 1.8.0
 argument-hint: <target-dir>
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
@@ -79,6 +79,24 @@ Inspect the target dir (`[target-dir]`, default cwd) before touching anything:
    - **Doc domains** — which of `providers/ brand/ domain/ business/
      infrastructure/ legal/ frontend/` apply. **Delete the folders that don't**
      (e.g. `frontend/` for a non-UI project).
+   - **Performance tooling** — detect what the stack offers, one slot at a
+     time (fixed checklist, first match per slot; record `none` explicitly
+     when nothing fits — never leave the slot undiscussed):
+     - *Static complexity lint*: Biome present → enable its `complexity`
+       group (incl. `noExcessiveCognitiveComplexity`); ESLint present →
+       suggest `eslint-plugin-sonarjs` + `eslint-plugin-unicorn`; neither →
+       ask for the stack's equivalent or record `none`.
+     - *Benchmark harness*: Vitest → `vitest bench`; Bun runtime → `mitata`;
+       Node → `tinybench`/`mitata`; other stacks → ask for the project's
+       benchmark command or record `none`.
+     - *Profiler*: Node → `node --cpu-prof` (zero-dependency default) or `0x`
+       via the project's package runner; Bun → `bun --inspect` CPU profiling;
+       other → ask or record `none`.
+     (The named tools are the TS/JS **adapter examples**; the contract is the
+     generic block below.) Offer installation — **the user confirms each
+     dependency; never install silently** — and register the outcome in the
+     template's `Performance commands` block next to the verification gate,
+     so `review-perf` can measure instead of guess.
    - **Naming conventions** and **MCP servers**, if any.
 4. **Write the adapted scaffold.** Fill the `CLAUDE.md` placeholders (commands,
    the documentation map rows, architecture); keep `AGENTS.md`, the

--- a/skills/review-perf/SKILL.md
+++ b/skills/review-perf/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-perf
 user-invocable: false
-version: 1.0.1
+version: 1.1.0
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
 description: >
@@ -40,6 +40,19 @@ default branch. State the scope at the top of the returned table.
 - ✓ Pagination/limits on any new listing that reads user-scaled data
 - ✓ No premature optimization either: complexity added for speed without a
   cited measurement is a finding (the repo forbids overengineering)
+- ✓ **Measured evidence when declared** — the project's agent guide declares a
+  `Performance commands` block with a `bench` command AND the diff touches
+  paths its benchmarks cover: RUN the benchmark on the base branch and on the
+  change, and cite both numbers in Evidence as
+  `<cmd> → base <x> / change <y> (<±z%>)`. A regression beyond the noise band
+  (the project's declared band, else ±5%) is a **major** finding; a delta
+  inside the band is no finding. The declared command failing (non-zero exit)
+  is itself a finding (the gate can't measure) — never silently skipped.
+- ✓ **No declared perf commands** → state exactly
+  `n/a — no declared perf commands` for the item above (never skip it
+  silently), and if the diff adds algorithmic code on input that can grow,
+  add a **minor** finding recommending the project adopt the tooling via
+  `init-workspace`'s Performance tooling round.
 
 ## Return exactly
 
@@ -48,7 +61,7 @@ REVIEW PERF — scope: <scope>
 
 | # | Finding | Sev | Evidence | Suggested fix |
 |---|---------|-----|----------|---------------|
-| 1 | <what>  | critical|major|minor | <file:line> | <smallest action> |
+| 1 | <what>  | critical|major|minor | <file:line — or, for measured findings, `<cmd> → base <x> / change <y> (<±z%>)`> | <smallest action> |
 
 Checklist: <n> evaluated, <n> pass, <n> findings, <n> n/a (<which + why>)
 Summary: <1-2 sentences>

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -110,6 +110,19 @@ Fill in your project's real commands. The agentic workflow refers to the
 <type-check> && <test> && <build>
 ```
 
+## Performance commands *(optional — filled by `init-workspace`; read by `review-perf`)*
+
+When declared, the workflow's performance review **runs** these and cites real
+numbers instead of estimating from the diff. Use `none` explicitly for a slot
+the project doesn't have; delete the block only if none apply.
+
+```
+- bench: <command | none>            # e.g. vitest bench, bun run bench.ts
+- profile: <command | none>          # e.g. node --cpu-prof <entry>
+- complexity-lint: <command | none>  # e.g. the linter's complexity ruleset
+- noise-band: ±5%                    # deltas inside the band are not findings
+```
+
 ---
 
 ## Architecture


### PR DESCRIPTION
## What

Feature `02-measured-perf-review` (size S, single-pass): performance review graduates from **reading the diff** to **running the project's declared measurements**.

- **`init-workspace` 1.8.0** — the interview gains a **Performance tooling** round with a fixed per-slot detection checklist (static complexity lint / benchmark harness / profiler). The TS/JS recipes are named as adapter examples (Biome `complexity` group or `eslint-plugin-sonarjs`+`unicorn`; `vitest bench` / `mitata` / `tinybench`; `node --cpu-prof` / `0x` / `bun --inspect`); every other stack goes through the generic "declare your commands" contract. Installation is always user-confirmed; the outcome lands in the template's new `Performance commands` block.
- **`review-perf` 1.1.0** (internal review pack) — new checklist items: when a `Performance commands` block is declared AND the diff touches benchmarked paths, the bench command is **run on base and change** and both numbers are cited as Evidence (`<cmd> → base <x> / change <y> (<±z%>)`). Regressions beyond the noise band (declared, default ±5%) are major; a failing bench command is itself a finding; no declared commands → the literal `n/a — no declared perf commands` plus a minor adopt-tooling finding when the diff adds algorithmic code on growable input. The report contract (`PASS | FAIL`) is unchanged, so `review-change`/`product-audit` need no changes.
- **`template/CLAUDE.md`** — optional `Performance commands` block (bench / profile / complexity-lint / noise-band) next to the verification gate.

## Why

`review-perf` could detect structural antipatterns but not verify a complexity claim or a regression — and its own checklist forbids optimization "without a cited measurement" that the workflow never produced. A finding backed by a number beats a finding backed by reading. SPEC: `docs/features/02-measured-perf-review/SPEC.md`.

## Evidence

- Gate: `npx skills add . --list` → exit 0.
- Stack-agnostic check: `grep -rln "mitata\|sonarjs\|tinybench\|0x" skills/` → only `skills/init-workspace/SKILL.md` (the marked adapter list); `review-perf` references only "the project's declared Performance commands".
- CHANGELOG EN/ES rows + release-log entries added; README tables unchanged (no new user-facing skill).

## Notes for reviewers

- **Merge after #8.** `init-workspace` jumps 1.6.0 → 1.8.0 here because 1.7.0 belongs to feature 01 (PR #8, Docs site round); both PRs add adjacent CHANGELOG rows and adjacent interview bullets — expect a trivial rebase if merged out of order. The roadmap row for this feature lives in #8's `ROADMAP.md`; its `done · #PR` link is pushed to that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
