### PR TITLE
fix(skills): reclassify bump-skill as internal (#40)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -20,7 +20,6 @@
   "skills": [
     "./skills/audit-docs",
     "./skills/audit-pr",
-    "./skills/bump-skill",
     "./skills/design-feature",
     "./skills/execute-phase",
     "./skills/generate-docs",

--- a/CHANGELOG.es.md
+++ b/CHANGELOG.es.md
@@ -95,20 +95,6 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 | 1.0.1 | 2026-06-27 | parche | Cierre normalizado al bloque canónico `→ Next:` |
 | 1.0.0 | 2026-06-19 | — | Nueva skill de diario de sesión. Añade una entrada estructurada a `docs/LOGS.md` (resumen, archivos, decisiones + por qué, siguiente paso) bajo demanda; `model: sonnet` (barato por diseño). Incluye hooks gratuitos y opt-in en `template/.claude/`: captura mecánica en SessionEnd + marcador en SessionStart, y restauración de contexto opt-in en SessionStart — todos sin modelo |
 
-### Mantenimiento del repo
-
-#### `bump-skill`
-| Versión | Fecha | Tipo | Qué cambió |
-|---|---|---|---|
-| 2.0.0 | 2026-07-10 | mayor | **Cambio incompatible:** se elimina la sección `## Machine envelope` y su cláusula de emisión en el contrato de turno — el contrato del envelope se traslada a la capa de orquestación; `workflow-status` sigue siendo el único emisor en línea. Además se retira la regla de lint "Machine envelope", ya obsoleta (exigía que toda skill de cara al usuario llevara la sección — ya no es cierto). Ver `docs/workflow/MIGRATION.md`. |
-| 1.5.0 | 2026-07-05 | menor | Envelope máquina: cada invocación termina ahora con un bloque JSON fijo (state, unit, phase, pr, findings, blockers, dependencies, next + pista de tier de modelo) para orquestación programática — esquema en la skill interna `orchestration-envelope`, protocolo en `docs/workflow/ORCHESTRATION.md`. El lint gana una 5ª regla: las skills de cara al usuario deben llevar la sección `## Machine envelope`. |
-| 1.3.1 | 2026-07-04 | parche | Sin cambio de comportamiento: el frontmatter `model:`/`effort:` de esta skill se trasladó a `docs/workflow/model-routing.yml` (usado solo para construir la rama `#claude`); la guía sobre modelos no-Claude en la descripción se sustituyó por un puntero a `#claude`. |
-| 1.3.0 | 2026-07-03 | menor | El lint comprueba también la nueva sección `## Turn contract` en las skills de cara al usuario. |
-| 1.2.1 | 2026-07-02 | parche | Nota de equivalencia de modelos en la descripción (edita model:/effort: para modelos no-Claude / de libre inferencia). |
-| 1.2.0 | 2026-07-02 | minor | El lint ahora comprueba también que las skills de cara al usuario llevan la sección `## Portability`; añadida su propia nota de Portability. |
-| 1.1.0 | 2026-06-27 | menor | Paso de lint que marca las skills editadas sin bloque `→ Next:` o con etiquetas de fase `S1`/"Step" (avisa, nunca corrige solo) |
-| 1.0.0 | 2026-06-19 | — | Nueva skill de mantenimiento del repo. Tras editar un SKILL.md, sube la `version:`, añade filas en CHANGELOG.md + CHANGELOG.es.md y actualiza las tablas de skills y modelos en README.md + README.es.md |
-
 ### De cara al usuario
 
 #### `generate-docs`
@@ -338,6 +324,15 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 
 | Skill | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|---|
+| `bump-skill` | 2.1.0 | 2026-07-11 | menor | Fix #40: reclasificada como `user-invocable: false` — la skill es mantenimiento del propio repo `agentic-workflow` y su entrada de menú `/bump-skill` era ruido para el ~99% de quienes consumen el paquete sin autorar sus `SKILL.md`. Sin cambio de comportamiento; se sigue ejecutando vía la herramienta Skill o siguiendo `SKILL.md` directamente. Su tabla por skill se traslada de "Mantenimiento del repo" a esta sección Interna. |
+| | 2.0.0 | 2026-07-10 | mayor | **Cambio incompatible:** se elimina la sección `## Machine envelope` y su cláusula de emisión en el contrato de turno — el contrato del envelope se traslada a la capa de orquestación; `workflow-status` sigue siendo el único emisor en línea. Además se retira la regla de lint "Machine envelope", ya obsoleta (exigía que toda skill de cara al usuario llevara la sección — ya no es cierto). Ver `docs/workflow/MIGRATION.md`. |
+| | 1.5.0 | 2026-07-05 | menor | Envelope máquina: cada invocación termina ahora con un bloque JSON fijo (state, unit, phase, pr, findings, blockers, dependencies, next + pista de tier de modelo) para orquestación programática — esquema en la skill interna `orchestration-envelope`, protocolo en `docs/workflow/ORCHESTRATION.md`. El lint gana una 5ª regla: las skills de cara al usuario deben llevar la sección `## Machine envelope`. |
+| | 1.3.1 | 2026-07-04 | parche | Sin cambio de comportamiento: el frontmatter `model:`/`effort:` de esta skill se trasladó a `docs/workflow/model-routing.yml` (usado solo para construir la rama `#claude`); la guía sobre modelos no-Claude en la descripción se sustituyó por un puntero a `#claude`. |
+| | 1.3.0 | 2026-07-03 | menor | El lint comprueba también la nueva sección `## Turn contract` en las skills de cara al usuario. |
+| | 1.2.1 | 2026-07-02 | parche | Nota de equivalencia de modelos en la descripción (edita model:/effort: para modelos no-Claude / de libre inferencia). |
+| | 1.2.0 | 2026-07-02 | minor | El lint ahora comprueba también que las skills de cara al usuario llevan la sección `## Portability`; añadida su propia nota de Portability. |
+| | 1.1.0 | 2026-06-27 | menor | Paso de lint que marca las skills editadas sin bloque `→ Next:` o con etiquetas de fase `S1`/"Step" (avisa, nunca corrige solo) |
+| | 1.0.0 | 2026-06-19 | — | Nueva skill de mantenimiento del repo. Tras editar un SKILL.md, sube la `version:`, añade filas en CHANGELOG.md + CHANGELOG.es.md y actualiza las tablas de skills y modelos en README.md + README.es.md |
 | `orchestration-envelope` | 1.1.1 | 2026-07-10 | parche | Fix #33: la descripción del frontmatter y la sección de apertura aún enunciaban el contrato previo a la feature 10 ("toda skill de cara al usuario imprime el envelope") POR ENCIMA de la corrección de la feature 10 — reescritas de cabeza al contrato vigente (esquema + regla de parseo último-json-cercado como núcleo; emisión = `workflow-status` siempre, el resto de skills solo bajo el snippet inyectado por el driver, nada en sesiones interactivas). La misma frase obsoleta corregida en `packages/agentic-workflow-schema/README.md`, `package.json`, `src/index.ts` y `envelope.schema.json` (solo texto de descripción/comentario/metadatos, sin cambio de forma del esquema ni de comportamiento, sin release del paquete). |
 | | 1.1.0 | 2026-07-10 | menor | Nueva sección `## Driver system-prompt snippet + repair loop`: el snippet canónico de system-prompt inyectado por el driver (verbatim, cercado) y el protocolo de bucle de reparación (fallo de parseo → reinvocar con "Emit only the machine envelope for the turn above.", un reintento, luego FAILED del driver) — el requisito del envelope se traslada aquí desde los contratos de turno por skill de las 14 skills de cara al usuario. |
 | | 1.0.0 | 2026-07-05 | — | Nuevo contrato interno: el esquema JSON del envelope máquina (11 estados, claves fijas, regla de parseo último-json-cercado) que toda skill de cara al usuario emite como su salida final absoluta. |
@@ -392,6 +387,15 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 
 ## Registro cronológico (más reciente primero)
 
+- **2026-07-11 — bump-skill reclasificada como interna (fix #40).** Bump
+  MENOR para `bump-skill` (2.1.0): `user-invocable: false` y eliminada del
+  array `skills` de `.claude-plugin/plugin.json` — la skill es mantenimiento
+  del propio repo `agentic-workflow`, así que su entrada de menú
+  `/bump-skill` era ruido para el ~99% de quienes solo consumen el paquete.
+  Sin cambio de comportamiento; se sigue ejecutando vía la herramienta Skill.
+  Conteos de skills reconciliados en `README.md`, `README.es.md` y
+  `docs/workflow/SKILLS.md` (15 de cara al usuario + 13 internas → 14 + 14).
+  Cierra #40.
 - **2026-07-11 — cierre por fases para unidades de pase único (fix #35).**
   Bumps MENORES de `plan-fix` (2.1.0), `plan-feature-scaffold` (1.8.0) y
   `execute-phase` (2.1.0): todo SPEC de fix y de feature XS/S lleva ahora un

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,20 +93,6 @@ How pinning actually works, verified against the `skills` CLI:
 | 1.0.1 | 2026-06-27 | patch | Closing normalized to the canonical `→ Next:` recommendation block |
 | 1.0.0 | 2026-06-19 | — | New session-journal skill. Appends a structured entry to `docs/LOGS.md` (summary, files, decisions + why, next step) on demand; `model: sonnet` (cheap by design). Ships with free, opt-in `template/.claude/` hooks: SessionEnd mechanical capture + SessionStart marker, and an opt-in SessionStart context-restore — all model-free |
 
-### Repo maintenance
-
-#### `bump-skill`
-| Version | Date | Type | What changed |
-|---|---|---|---|
-| 2.0.0 | 2026-07-10 | major | **Breaking:** dropped the `## Machine envelope` section and its turn-contract emission clause — the envelope contract moved to the orchestration layer; `workflow-status` remains the sole inline emitter. Also retired the now-obsolete "Machine envelope" lint rule (it required every user-facing skill to carry the section — no longer true). See `docs/workflow/MIGRATION.md`. |
-| 1.5.0 | 2026-07-05 | minor | Machine envelope: every invocation now ends with a fixed JSON block (state, unit, phase, pr, findings, blockers, dependencies, next + model-tier hint) for programmatic orchestration — schema in the internal `orchestration-envelope` skill, protocol in `docs/workflow/ORCHESTRATION.md`. Lint gains a 5th rule: user-facing skills must carry the `## Machine envelope` section. |
-| 1.3.1 | 2026-07-04 | patch | No behavior change: this skill's `model:`/`effort:` frontmatter moved to `docs/workflow/model-routing.yml` (used only to build the `#claude` branch); the description's non-Claude guidance was replaced with a pointer to `#claude`. |
-| 1.3.0 | 2026-07-03 | minor | Lint also checks the new `## Turn contract` section on user-facing skills. |
-| 1.2.1 | 2026-07-02 | patch | Model-equivalence note in the description (edit model:/effort: for non-Claude / free-inference models). |
-| 1.2.0 | 2026-07-02 | minor | Lint now also checks that user-facing skills carry the `## Portability` section; added its own Portability note. |
-| 1.1.0 | 2026-06-27 | minor | Lint step flags edited skills missing a `→ Next:` block or using `S1`/"Step" phase labels (warns, never auto-fixes) |
-| 1.0.0 | 2026-06-19 | — | New repo-maintenance skill. After editing a SKILL.md, bumps `version:`, adds rows to CHANGELOG.md + CHANGELOG.es.md, and updates the skills and model tables in README.md + README.es.md |
-
 ### User-facing
 
 #### `generate-docs`
@@ -336,6 +322,15 @@ How pinning actually works, verified against the `skills` CLI:
 
 | Skill | Version | Date | Type | What changed |
 |---|---|---|---|---|
+| `bump-skill` | 2.1.0 | 2026-07-11 | minor | Fix #40: reclassified `user-invocable: false` — the skill is repo-maintenance for `agentic-workflow` itself and its `/bump-skill` menu entry was pure noise for the ~99% of consumers who don't author this pack's `SKILL.md` files. Behavior unchanged; still run via the Skill tool or by following `SKILL.md` directly. Per-skill table moved from "Repo maintenance" (User-facing-adjacent) to this Internal section. |
+| | 2.0.0 | 2026-07-10 | major | **Breaking:** dropped the `## Machine envelope` section and its turn-contract emission clause — the envelope contract moved to the orchestration layer; `workflow-status` remains the sole inline emitter. Also retired the now-obsolete "Machine envelope" lint rule (it required every user-facing skill to carry the section — no longer true). See `docs/workflow/MIGRATION.md`. |
+| | 1.5.0 | 2026-07-05 | minor | Machine envelope: every invocation now ends with a fixed JSON block (state, unit, phase, pr, findings, blockers, dependencies, next + model-tier hint) for programmatic orchestration — schema in the internal `orchestration-envelope` skill, protocol in `docs/workflow/ORCHESTRATION.md`. Lint gains a 5th rule: user-facing skills must carry the `## Machine envelope` section. |
+| | 1.3.1 | 2026-07-04 | patch | No behavior change: this skill's `model:`/`effort:` frontmatter moved to `docs/workflow/model-routing.yml` (used only to build the `#claude` branch); the description's non-Claude guidance was replaced with a pointer to `#claude`. |
+| | 1.3.0 | 2026-07-03 | minor | Lint also checks the new `## Turn contract` section on user-facing skills. |
+| | 1.2.1 | 2026-07-02 | patch | Model-equivalence note in the description (edit model:/effort: for non-Claude / free-inference models). |
+| | 1.2.0 | 2026-07-02 | minor | Lint now also checks that user-facing skills carry the `## Portability` section; added its own Portability note. |
+| | 1.1.0 | 2026-06-27 | minor | Lint step flags edited skills missing a `→ Next:` block or using `S1`/"Step" phase labels (warns, never auto-fixes) |
+| | 1.0.0 | 2026-06-19 | — | New repo-maintenance skill. After editing a SKILL.md, bumps `version:`, adds rows to CHANGELOG.md + CHANGELOG.es.md, and updates the skills and model tables in README.md + README.es.md |
 | `orchestration-envelope` | 1.1.1 | 2026-07-10 | patch | Fix #33: the frontmatter description and opening section still stated the pre-feature-10 contract ("every user-facing skill prints the envelope") ABOVE the feature-10 correction — rewritten head-first to the current contract (schema + last-fenced-json parse rule as the core; emission = `workflow-status` always, other skills only under the driver-injected snippet, nothing in interactive sessions). Same stale sentence fixed in `packages/agentic-workflow-schema/README.md`, `package.json`, `src/index.ts`, and `envelope.schema.json` (description/comment/metadata text only, no schema-shape or code-behavior change, no package release needed). |
 | | 1.1.0 | 2026-07-10 | minor | New `## Driver system-prompt snippet + repair loop` section: the canonical driver-injected system-prompt snippet (verbatim, fenced) and the repair-loop protocol (parse-fail → re-invoke with "Emit only the machine envelope for the turn above.", one retry, then driver-level FAILED) — the envelope requirement moved here from the 14 user-facing skills' per-skill turn contracts. |
 | | 1.0.0 | 2026-07-05 | — | New internal contract: the machine-envelope JSON schema (11 states, fixed keys, last-fenced-json parse rule) every user-facing skill emits as its absolute last output. |
@@ -390,6 +385,15 @@ How pinning actually works, verified against the `skills` CLI:
 
 ## Release log (chronological, newest first)
 
+- **2026-07-11 — bump-skill reclassified internal (fix #40).** MINOR bump for
+  `bump-skill` (2.1.0): `user-invocable: false` and dropped from
+  `.claude-plugin/plugin.json`'s `skills` array — the skill is
+  repo-maintenance for `agentic-workflow` itself, so its `/bump-skill` menu
+  entry was noise for the ~99% of consumers who don't author this pack's
+  `SKILL.md` files. No behavior change; still run via the Skill tool. Skill
+  counts reconciled across `README.md`, `README.es.md`, and
+  `docs/workflow/SKILLS.md` (15 user-facing + 13 internal → 14 + 14). Closes
+  #40.
 - **2026-07-11 — phased close-out for single-pass units (fix #35).** MINOR
   bumps for `plan-fix` (2.1.0), `plan-feature-scaffold` (1.8.0), and
   `execute-phase` (2.1.0): every fix SPEC and XS/S feature SPEC now carries a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,3 +238,5 @@ reusable operational knowledge as a skill under `skills/`.
   It bumps `version:`, adds changelog rows to `CHANGELOG.md` and
   `CHANGELOG.es.md`, and updates the skills and model tables in both READMEs.
   This is the mechanical enforcement of the "Version every change" rule above.
+  `bump-skill` itself is `user-invocable: false` — invoke it via the Skill
+  tool / by following its `SKILL.md` directly, not the slash-command menu.

--- a/README.es.md
+++ b/README.es.md
@@ -54,7 +54,7 @@ agente** que lea skills — Claude Code, Cursor, Codex, OpenCode, Cline y
 ## Qué incluye
 
 ```
-skills/                  las 28 skills (15 de cara al usuario + 13 internas) — la fuente instalable
+skills/                  las 28 skills (14 de cara al usuario + 14 internas) — la fuente instalable
 .claude/skills           symlink → ../skills, para que este repo las use en Claude Code
 template/                 el scaffold de documentación exportable (el sustrato que leen las skills)
 docs/workflow/           el tutorial completo (flujo de feature, de issue, referencia, replicación)
@@ -71,11 +71,12 @@ plantillas de GitHub). Genera la forma de trabajo de un proyecto nuevo con
 
 ## Las skills
 
-**15 skills de cara al usuario** (una entrada de menú cada una) + **13 internas**
+**14 skills de cara al usuario** (una entrada de menú cada una) + **14 internas**
 que se componen por ti: los dos pasos de planificación del router `plan-feature`,
-el motor de `review-change`, el contrato `orchestration-envelope`, y el **pack de revisión interno propio de 9 skills**
+el motor de `review-change`, el contrato `orchestration-envelope`, el **pack de revisión interno propio de 9 skills**
 (`review-code`, `review-security`, `review-verify`, `review-debt`,
-`review-design`, `review-a11y`, `review-brand`, `review-perf`, `review-seo`) —
+`review-design`, `review-a11y`, `review-brand`, `review-perf`, `review-seo`), y
+el ayudante de mantenimiento interno `bump-skill` —
 así que **nunca se requiere una skill de revisión externa**, en ningún agente y
 con ningún modelo. Un único camino disciplinado:
 **design → plan → execute → review → audit → merge.**

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ reads skills — Claude Code, Cursor, Codex, OpenCode, Cline, and
 ## What's inside
 
 ```
-skills/                  the 28 skills (15 user-facing + 13 internal) — the installable source
+skills/                  the 28 skills (14 user-facing + 14 internal) — the installable source
 .claude/skills           symlink → ../skills, so this repo dogfoods them in Claude Code
 template/                 the exportable documentation scaffold (the substrate the skills read)
 docs/workflow/           the full tutorial (feature flow, issue flow, reference, replication)
@@ -70,13 +70,14 @@ templates). Scaffold a new project's way of working with
 
 ## The skills
 
-**15 user-facing skills** (one menu entry each) + **13 internal** ones composed
+**14 user-facing skills** (one menu entry each) + **14 internal** ones composed
 for you: the `plan-feature` router's two planning steps, the `review-change`
-engine, the `orchestration-envelope` contract, and the workflow's **own 9-skill internal review pack** (`review-code`,
+engine, the `orchestration-envelope` contract, the workflow's **own 9-skill internal review pack** (`review-code`,
 `review-security`, `review-verify`, `review-debt`, `review-design`,
-`review-a11y`, `review-brand`, `review-perf`, `review-seo`) — so **no external
-review skill is ever required**, on any agent, with any model. One disciplined
-path: **design → plan → execute → review → audit → merge.**
+`review-a11y`, `review-brand`, `review-perf`, `review-seo`), and the repo-only
+`bump-skill` maintenance helper — so **no external review skill is ever
+required**, on any agent, with any model. One disciplined path: **design →
+plan → execute → review → audit → merge.**
 
 > Every skill's invocation forms and flags (`--fix`, `--force`,
 > `--adversarial N`, `--next`, `--fullauto`, …) are catalogued in the

--- a/docs/fix/40-bump-skill-internal-only/SPEC.md
+++ b/docs/fix/40-bump-skill-internal-only/SPEC.md
@@ -165,7 +165,7 @@ ticks tasks here.
 
 ### P2 — Hardening & PR
 
-- [ ] Run `bump-skill` on `bump-skill` (recommended **minor** bump —
+- [x] Run `bump-skill` on `bump-skill` (recommended **minor** bump —
       metadata reclassification, zero behavior change; if `bump-skill`'s own
       diff analysis judges the removal of the `/bump-skill` menu surface a
       contract change, **major** is acceptable — the executor decides). Ensure
@@ -173,12 +173,12 @@ ticks tasks here.
       the **Internal (`user-invocable: false`)** subsection in both
       `CHANGELOG.md` and `CHANGELOG.es.md` (an existing table is not auto-moved —
       move it by hand if the tool leaves it under "User-facing").
-- [ ] Re-run the project's full verification gate (commands + exit codes pasted):
+- [x] Re-run the project's full verification gate (commands + exit codes pasted):
       `python3 -c "import json;d=json.load(open('.claude-plugin/plugin.json'));assert './skills/bump-skill' not in d['skills'] and len(d['skills'])==27"`
       (exit 0); `npx skills add . --list` (discovers 28); the Acceptance
       grep checks (all pass).
-- [ ] Pending-docs check: `git status --porcelain -- docs/` → empty
-- [ ] Set the fix-index row status to `done` and commit the flip
+- [x] Pending-docs check: `git status --porcelain -- docs/` → empty
+- [x] Set the fix-index row status to `done` and commit the flip
 - [ ] `git push`
 - [ ] Open the PR (`gh pr create --body-file <path>` — body written as a
       Markdown file, real backticks, never inline `--body`/heredoc) and
@@ -333,4 +333,4 @@ implementation phase + the standard close-out.
 
 ## Status
 
-`pending`
+`done`

--- a/docs/fix/40-bump-skill-internal-only/SPEC.md
+++ b/docs/fix/40-bump-skill-internal-only/SPEC.md
@@ -1,0 +1,336 @@
+# fix/40-bump-skill-internal-only
+
+## Goal
+
+`bump-skill` is repo-maintenance for `agentic-workflow` itself, yet it ships
+`user-invocable: true` and is enumerated in the Claude Code plugin manifest —
+so every consumer of `npx skills add gtrabanco/agentic-workflow` gets a
+`/bump-skill` slash-menu entry that does nothing for them (they aren't authoring
+this pack's `SKILL.md` files or maintaining its CHANGELOG/README). This fix
+reclassifies `bump-skill` as an **internal** skill (`user-invocable: false`) and
+drops it from the plugin manifest, removing the menu entry for every consumer
+via both distribution channels, and reconciles the skill-count docs that assume
+the old user-facing classification. It's small but worth doing now because it's
+the one skill whose menu surface is pure noise for ~99% of installs, and the
+inconsistency (a skill whose own description says "Internal skill for the
+agentic-workflow repo" while flagged `user-invocable: true`) is already
+confusing the docs.
+
+## Issue
+
+`#40` — GitHub issue. Required. The PR must close it via `Closes #40` in the
+body.
+
+## Branch
+
+`fix/40-bump-skill-internal-only`
+
+## Depends on
+
+None — independent.
+
+## Root cause
+
+`bump-skill` was authored `user-invocable: true` (`skills/bump-skill/SKILL.md:3`)
+because the repo's own maintainers invoked it as a slash command, and it was
+added to the plugin manifest's `skills` array
+(`.claude-plugin/plugin.json:23`) alongside the genuinely user-facing skills.
+The `skills` CLI has **no way to exclude a skill from a default install** (see
+Decisions made during drafting), so the only levers that remove the menu entry
+are the skill's own `user-invocable` flag and the plugin manifest — neither was
+set to "internal", so the entry leaks into every install.
+
+## Detected in
+
+User conversation, 2026-07-11 — the user asked whether `bump-skill` should
+appear in user-facing docs at all; confirmed it is `user-invocable: true` (not
+the repo's technical "internal" category) but scoped to maintaining this repo
+specifically, and gets installed into every consumer project regardless. Filed
+as issue #40.
+
+## Scope
+
+### In scope
+
+The smallest change set that removes the `/bump-skill` menu entry for consumers
+and keeps the repo's docs internally consistent:
+
+1. **`skills/bump-skill/SKILL.md`** — frontmatter `user-invocable: true` →
+   `user-invocable: false`. This is the single change that removes the skill from
+   the slash-command menu on every agent that honors the flag (Claude Code and
+   the 70+ others). Nothing else in the file changes.
+2. **`.claude-plugin/plugin.json`** — remove the `"./skills/bump-skill"` entry
+   from the `skills` array (drops it from the Claude Code plugin channel). JSON
+   stays valid; the array goes from 28 to 27 entries.
+3. **`docs/workflow/SKILLS.md`** — remove the `/bump-skill` row from the
+   "invocation forms" table (§ "Every user-invocable skill's invocation forms");
+   move `bump-skill` out of the "Of the 15" user-facing enumeration into the
+   internal set; update the count header `15 user-facing … + 13 internal` →
+   `14 user-facing … + 14 internal`.
+4. **`README.md`** — update both skill-count occurrences to `14 user-facing +
+   14 internal` (the layout block "the 28 skills (15 user-facing + 13 internal)"
+   and the prose "**15 user-facing skills** … + **13 internal**").
+5. **`README.es.md`** — the same two count occurrences, in Spanish
+   (`15 de cara al usuario + 13 internas` → `14 … + 14 …`).
+6. **`CLAUDE.md`** — in the "Repo maintenance skill (specific to this repo)"
+   note, add that `bump-skill` is now `user-invocable: false` (invoked via the
+   Skill tool / by following its `SKILL.md`, not the slash menu).
+7. **Bookkeeping** (in the Hardening phase, via `bump-skill` itself): bump
+   `bump-skill`'s `version:`, add the changelog rows, and **move** its per-skill
+   table from the "User-facing" subsection to the "Internal
+   (`user-invocable: false`)" subsection in both `CHANGELOG.md` and
+   `CHANGELOG.es.md`.
+
+### Out of scope
+
+- **Physically excluding `bump-skill` from a default CLI install.** Verified
+  impossible: the `skills` CLI scans the filesystem and copies all discovered
+  `SKILL.md` files; it has no `--exclude` flag and no per-skill manifest field to
+  skip one (`--metadata` is telemetry-only). A default `npx skills add` still
+  **copies** the `bump-skill` folder — but with `user-invocable: false` it no
+  longer surfaces in the menu, which is the actual harm. Documenting a consumer
+  opt-out (`npx skills remove bump-skill`) belongs to a docs follow-up if ever
+  wanted, not here.
+- **Rewriting historical feature/fix docs** that mention "run `bump-skill`"
+  (`docs/features/**`, `docs/fix/35-*`). Those are accurate records of past runs;
+  `bump-skill` still exists and still does the bookkeeping — only its menu surface
+  changes. Track-don't-inline: not part of this fix.
+- **Removing `bump-skill`'s `## Turn contract` / `## Portability` sections.**
+  Harmless on an internal skill; not required to close #40. If ever tidied, that
+  is a separate `bump-skill` edit.
+- **Spanish sibling of `docs/workflow/SKILLS.md`** — does not exist yet (issue
+  #37 tracks creating Spanish siblings for `docs/workflow/*.md`). When #37 lands,
+  its Spanish `SKILLS.md` must carry the `14 + 14` count; nothing to do here.
+
+## Acceptance
+
+Objective, verifiable conditions for "done":
+
+- [ ] `grep -n '^user-invocable:' skills/bump-skill/SKILL.md` shows
+      `user-invocable: false`.
+- [ ] `.claude-plugin/plugin.json` parses as valid JSON and its `skills` array
+      has 27 entries with `./skills/bump-skill` **absent**
+      (`python3 -c "import json;d=json.load(open('.claude-plugin/plugin.json'));assert './skills/bump-skill' not in d['skills'];assert len(d['skills'])==27"`).
+- [ ] `grep -rn '/bump-skill' docs/workflow/SKILLS.md` returns **nothing** (the
+      slash-form invocation row is gone).
+- [ ] No live doc states the old split: `grep -rn '15 user-facing\|13 internal\|15 de cara al usuario\|13 internas' README.md README.es.md docs/workflow/SKILLS.md`
+      returns nothing; each of those files instead states `14 user-facing +
+      14 internal` (or the Spanish equivalent) once per prior occurrence.
+- [ ] `CLAUDE.md` "Repo maintenance skill" note states `bump-skill` is
+      `user-invocable: false` (invoked via the Skill tool, not the slash menu).
+- [ ] `bump-skill`'s `version:` was bumped and its per-skill changelog table
+      lives under the **Internal (`user-invocable: false`)** subsection in both
+      `CHANGELOG.md` and `CHANGELOG.es.md`, each with a new row for this change.
+- [ ] `npx skills add . --list` still discovers all 28 skills (the CLI scan is
+      unchanged — expected; menu visibility is governed by the flag, not the
+      scan).
+- [ ] Updated `docs/workflow/SKILLS.md`, `README.md`, `README.es.md`, `CLAUDE.md`
+      (the "Affected docs" list) — each has its acceptance criterion above.
+
+## Phases
+
+Execution ledger — `execute-phase --fix` runs **one phase per invocation** and
+ticks tasks here.
+
+### P1 — Reclassify bump-skill as internal (flag + manifest + count docs)
+
+- [ ] `skills/bump-skill/SKILL.md`: change frontmatter `user-invocable: true`
+      → `user-invocable: false`. Touch nothing else in the file. Verify:
+      `grep -n '^user-invocable:' skills/bump-skill/SKILL.md` → `false`.
+- [ ] `.claude-plugin/plugin.json`: remove the `"./skills/bump-skill",` line
+      from the `skills` array; keep valid JSON. Verify with the acceptance
+      one-liner (parses, 27 entries, `./skills/bump-skill` absent).
+- [ ] `docs/workflow/SKILLS.md`: (a) delete the
+      `| \`bump-skill\` | \`/bump-skill\` | … |` row from the invocation-forms
+      table; (b) update the count sentence `**15 user-facing skills** … + **13
+      internal**` → `**14 user-facing skills** … + **14 internal**`; (c) in the
+      "Of the 15: 12 core workflow skills, a `log-session` … a `workflow-status`
+      … and the repo-only `bump-skill` maintenance helper" sentence, move
+      `bump-skill` out of the user-facing tally and describe it as an internal
+      maintenance helper (adjust the "Of the 15" wording to "Of the 14"
+      accordingly). Verify: `grep -rn '/bump-skill' docs/workflow/SKILLS.md`
+      returns nothing.
+- [ ] `README.md`: update both count occurrences (layout block line ~56 and
+      prose line ~73) `15 user-facing + 13 internal` → `14 user-facing +
+      14 internal`.
+- [ ] `README.es.md`: update both count occurrences (layout block line ~57 and
+      prose line ~74) `15 de cara al usuario + 13 internas` → `14 de cara al
+      usuario + 14 internas`.
+- [ ] `CLAUDE.md`: in the "Repo maintenance skill (specific to this repo)"
+      block, add a clause that `bump-skill` is now `user-invocable: false` —
+      invoked via the Skill tool / by following its `SKILL.md`, not the slash
+      menu.
+- [ ] Gate for this phase: JSON validity + the grep checks above all pass;
+      `npx skills add . --list` still reports 28 skills.
+
+### P2 — Hardening & PR
+
+- [ ] Run `bump-skill` on `bump-skill` (recommended **minor** bump —
+      metadata reclassification, zero behavior change; if `bump-skill`'s own
+      diff analysis judges the removal of the `/bump-skill` menu surface a
+      contract change, **major** is acceptable — the executor decides). Ensure
+      it adds the changelog rows AND **moves** `bump-skill`'s per-skill table to
+      the **Internal (`user-invocable: false`)** subsection in both
+      `CHANGELOG.md` and `CHANGELOG.es.md` (an existing table is not auto-moved —
+      move it by hand if the tool leaves it under "User-facing").
+- [ ] Re-run the project's full verification gate (commands + exit codes pasted):
+      `python3 -c "import json;d=json.load(open('.claude-plugin/plugin.json'));assert './skills/bump-skill' not in d['skills'] and len(d['skills'])==27"`
+      (exit 0); `npx skills add . --list` (discovers 28); the Acceptance
+      grep checks (all pass).
+- [ ] Pending-docs check: `git status --porcelain -- docs/` → empty
+- [ ] Set the fix-index row status to `done` and commit the flip
+- [ ] `git push`
+- [ ] Open the PR (`gh pr create --body-file <path>` — body written as a
+      Markdown file, real backticks, never inline `--body`/heredoc) and
+      PRINT THE PR URL in the chat; the body includes `Closes #40`
+- [ ] Update the fix-index row to `done · [#<pr>](<pr-url>)`
+- [ ] Commit `docs: link PR #40` and push
+
+## Testing
+
+No application build exists (docs/packaging change). "Green" is the repo's own
+verification, exercised as architecture-style assertions:
+
+- **JSON contract** — `.claude-plugin/plugin.json` parses and the `skills` array
+  is exactly the 27 remaining skills (Python `json.load` + `assert`).
+- **CLI discovery** — `npx skills add . --list` still enumerates all 28 skills
+  (proves the scan is untouched; the flip changes menu visibility, not
+  discovery).
+- **Grep invariants** — no `/bump-skill` slash-form in `docs/workflow/SKILLS.md`;
+  no `15 user-facing`/`13 internal` (or Spanish) strings remain in the live docs;
+  `user-invocable: false` present in the SKILL.md.
+
+There is no runtime unit/integration layer to add; the menu-visibility behavior
+is an agent-runtime property of the flag and is verified manually (see
+Observability).
+
+## Impact
+
+- **Layers touched** — distribution/packaging metadata (`SKILL.md` frontmatter,
+  `plugin.json`) and documentation (`SKILLS.md`, `README*.md`, `CLAUDE.md`,
+  `CHANGELOG*.md`). No skill **behavior** changes.
+- **Modules and files** — `skills/bump-skill/SKILL.md`,
+  `.claude-plugin/plugin.json`, `docs/workflow/SKILLS.md`, `README.md`,
+  `README.es.md`, `CLAUDE.md`, `CHANGELOG.md`, `CHANGELOG.es.md`.
+- **Blast radius** — dev-/consumer-experience only: one slash-menu entry
+  disappears. No data, no runtime, no schema, no CI logic touched. This repo's
+  own maintainers lose the `/bump-skill` slash shortcut but keep the skill via
+  the Skill tool (confirmed invocable — internal skills such as
+  `review-implementation`, `plan-feature-scaffold`, `orchestration-envelope` are
+  invoked via the Skill tool, not the menu). The user confirmed they never invoke
+  `/bump-skill` manually; it is already run for them via the Skill tool.
+- **Detection lead time** — immediate and self-evident: the acceptance greps
+  fail loudly if any piece is missed; a wrong menu state is visible the moment an
+  agent lists its skills.
+
+## Rules that must never be violated
+
+- **Docs language is English** for committed artifacts; the Spanish
+  `README.es.md`/`CHANGELOG.es.md` edits are exact translations of the English
+  changes, not new content.
+- **Stack/architecture agnostic** — no product/stack/framework reference
+  introduced.
+- **Version every change** — any `SKILL.md` edit ⇒ a `version:` bump + changelog
+  rows in the same PR (`bump-skill`'s own rule; enforced in P2).
+- **`bump-skill` never edits a `SKILL.md` beyond its `version:` line** — the
+  `user-invocable` flip is a manual P1 edit, not something `bump-skill` performs.
+- **One PR per unit of work, against `main`** — this fix is a single PR off
+  `main`.
+
+## Operational risks
+
+- **Self-referential execution.** P2 runs `bump-skill` immediately after P1 makes
+  `bump-skill` internal in the same working tree. Internal skills remain invocable
+  via the Skill tool, so this works; but a running agent session may have cached
+  the pre-flip registry (precedent: feature 10 hit a stale globally-installed
+  copy at `~/.claude/skills/bump-skill/`). Mitigation: if the Skill tool won't
+  surface the freshly-edited `bump-skill`, perform the version/changelog
+  bookkeeping by hand following `skills/bump-skill/SKILL.md` — `execute-phase`
+  already knows this fallback.
+- No scheduled-job, queue, cache-invalidation, schema, or external-adapter
+  interaction. The npm schema package (`packages/agentic-workflow-schema/`) is
+  untouched, so the CLAUDE.md "same-PR schema mirror" rule does not apply.
+
+## Security risks
+
+n/a — no auth, secrets, PII, webhooks, or rate-limits touched. Packaging/docs
+only.
+
+## Compliance touchpoints
+
+n/a — no domain/compliance rules (data retention, regional, consumer-protection)
+are involved.
+
+## Affected docs
+
+Each is already an acceptance criterion above:
+
+- `docs/workflow/SKILLS.md` — remove the `/bump-skill` invocation row; reclassify
+  `bump-skill` as internal; fix the `14 + 14` count.
+- `README.md` — both skill-count occurrences → `14 user-facing + 14 internal`.
+- `README.es.md` — both skill-count occurrences (Spanish) → `14 + 14`.
+- `CLAUDE.md` — note `bump-skill` is `user-invocable: false` (Skill-tool /
+  `SKILL.md`, not slash menu).
+- `CHANGELOG.md` / `CHANGELOG.es.md` — new `bump-skill` rows, table moved to the
+  Internal subsection (P2, via `bump-skill`).
+
+## Observability
+
+No production surface (this is a skills pack, not a running app). The fix is
+"live and healthy" when, after a consumer runs `npx skills update` (or a fresh
+`npx skills add`), the agent's skill/command menu no longer offers `/bump-skill`.
+The in-repo, scriptable proxies are the acceptance greps (`user-invocable: false`
+present; `/bump-skill` absent from `SKILLS.md`; `plugin.json` array = 27 without
+`bump-skill`). There is no log line or metric; degradation would show up only as
+the menu entry reappearing, caught by the acceptance greps on the next change.
+
+## Cross-issue notes
+
+- **#42** (enhancement — injection-safe urgency, `triage-issue`/`workflow-status`)
+  — unrelated. No overlap.
+- **#38** (bug — npm schema publish stuck at 1.0.0) — unrelated; touches the
+  schema package, not the skills classification.
+- **#37** (documentation — `docs/workflow/*.md` has no Spanish sibling) —
+  **parallel, not blocking**. The Spanish `SKILLS.md` sibling does not exist yet,
+  so there is nothing to mirror now; when #37 creates it, it must carry the
+  `14 + 14` count. Recorded so #37 doesn't silently reintroduce the old split.
+- No open PRs — nothing to rebase against.
+
+## Effort
+
+**S** — one manual frontmatter flip, one small JSON edit, and mechanical
+count/reclassification edits across four docs plus the P2 changelog bookkeeping.
+Multiple files but zero design decisions; ≤ a couple of hours, effectively one
+implementation phase + the standard close-out.
+
+## Decisions made during drafting
+
+- **Approach A chosen by the user** (`user-invocable: false` + drop from
+  `plugin.json`) over "document a CLI opt-out" (issue option 1) or "docs-only
+  wording tightening" (issue option 2). Rationale: A is the only approach that
+  actually removes the menu entry for every consumer via both channels, and it
+  aligns the flag with the skill's own "Internal skill for the agentic-workflow
+  repo" self-description. The user confirmed they never invoke `/bump-skill`
+  manually (it is run for them via the Skill tool), so the maintainer-side cost
+  is effectively zero.
+- **Issue option 3 (CLI auto-skips via metadata) verified impossible.** Checked
+  against the actual CLI (`npx skills add --help` / root help): the only
+  install-time selector is `--skill` (an **allowlist**, supporting `*`); there is
+  **no `--exclude`** flag and **no frontmatter/manifest field** the CLI honors to
+  skip a skill (`--metadata <json>` attaches JSON to install telemetry only). The
+  CLI discovers skills by **filesystem scan** (`npx skills add . --list` reports
+  "Found 28 skills"), independent of `plugin.json`. So the CLI channel cannot be
+  made to omit `bump-skill` on a default install — hence the flag-based approach.
+- **Recommended bump: minor** (`2.0.0 → 2.1.0`) — metadata reclassification with
+  no behavior/contract change to the skill's process, arguments, or output. If
+  `bump-skill`'s own diff analysis judges the removal of the `/bump-skill` menu
+  surface a contract change, a **major** bump is acceptable; the executor
+  (running `bump-skill`) makes the final call in P2.
+- **CLI still copies the `bump-skill` folder** on a default install (unavoidable,
+  per option-3 finding). Accepted: `user-invocable: false` means it never
+  surfaces in the menu, so the copied-but-hidden folder is invisible noise, not
+  menu noise. Not worth a follow-up unless a consumer complains about the folder.
+
+## Status
+
+`pending`

--- a/docs/fix/40-bump-skill-internal-only/SPEC.md
+++ b/docs/fix/40-bump-skill-internal-only/SPEC.md
@@ -179,12 +179,12 @@ ticks tasks here.
       grep checks (all pass).
 - [x] Pending-docs check: `git status --porcelain -- docs/` → empty
 - [x] Set the fix-index row status to `done` and commit the flip
-- [ ] `git push`
-- [ ] Open the PR (`gh pr create --body-file <path>` — body written as a
+- [x] `git push`
+- [x] Open the PR (`gh pr create --body-file <path>` — body written as a
       Markdown file, real backticks, never inline `--body`/heredoc) and
       PRINT THE PR URL in the chat; the body includes `Closes #40`
-- [ ] Update the fix-index row to `done · [#<pr>](<pr-url>)`
-- [ ] Commit `docs: link PR #40` and push
+- [x] Update the fix-index row to `done · [#<pr>](<pr-url>)`
+- [x] Commit `docs: link PR #40` and push
 
 ## Testing
 

--- a/docs/fix/40-bump-skill-internal-only/SPEC.md
+++ b/docs/fix/40-bump-skill-internal-only/SPEC.md
@@ -134,13 +134,13 @@ ticks tasks here.
 
 ### P1 — Reclassify bump-skill as internal (flag + manifest + count docs)
 
-- [ ] `skills/bump-skill/SKILL.md`: change frontmatter `user-invocable: true`
+- [x] `skills/bump-skill/SKILL.md`: change frontmatter `user-invocable: true`
       → `user-invocable: false`. Touch nothing else in the file. Verify:
       `grep -n '^user-invocable:' skills/bump-skill/SKILL.md` → `false`.
-- [ ] `.claude-plugin/plugin.json`: remove the `"./skills/bump-skill",` line
+- [x] `.claude-plugin/plugin.json`: remove the `"./skills/bump-skill",` line
       from the `skills` array; keep valid JSON. Verify with the acceptance
       one-liner (parses, 27 entries, `./skills/bump-skill` absent).
-- [ ] `docs/workflow/SKILLS.md`: (a) delete the
+- [x] `docs/workflow/SKILLS.md`: (a) delete the
       `| \`bump-skill\` | \`/bump-skill\` | … |` row from the invocation-forms
       table; (b) update the count sentence `**15 user-facing skills** … + **13
       internal**` → `**14 user-facing skills** … + **14 internal**`; (c) in the
@@ -150,17 +150,17 @@ ticks tasks here.
       maintenance helper (adjust the "Of the 15" wording to "Of the 14"
       accordingly). Verify: `grep -rn '/bump-skill' docs/workflow/SKILLS.md`
       returns nothing.
-- [ ] `README.md`: update both count occurrences (layout block line ~56 and
+- [x] `README.md`: update both count occurrences (layout block line ~56 and
       prose line ~73) `15 user-facing + 13 internal` → `14 user-facing +
       14 internal`.
-- [ ] `README.es.md`: update both count occurrences (layout block line ~57 and
+- [x] `README.es.md`: update both count occurrences (layout block line ~57 and
       prose line ~74) `15 de cara al usuario + 13 internas` → `14 de cara al
       usuario + 14 internas`.
-- [ ] `CLAUDE.md`: in the "Repo maintenance skill (specific to this repo)"
+- [x] `CLAUDE.md`: in the "Repo maintenance skill (specific to this repo)"
       block, add a clause that `bump-skill` is now `user-invocable: false` —
       invoked via the Skill tool / by following its `SKILL.md`, not the slash
       menu.
-- [ ] Gate for this phase: JSON validity + the grep checks above all pass;
+- [x] Gate for this phase: JSON validity + the grep checks above all pass;
       `npx skills add . --list` still reports 28 skills.
 
 ### P2 — Hardening & PR

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -17,7 +17,7 @@ this table — history lives in git log + closed issues.
 | [33-stale-envelope-contract](33-stale-envelope-contract/SPEC.md) | Pre-feature-10 envelope contract still stated in orchestration-envelope's head + schema-package README | done | — | [#33](https://github.com/gtrabanco/agentic-workflow/issues/33) |
 | [35-single-pass-closeout-phase](35-single-pass-closeout-phase/SPEC.md) | Single-pass units drop the close-out chain — always emit a final Hardening & PR phase (≥ 2 phases) | done · [#36](https://github.com/gtrabanco/agentic-workflow/pull/36) | — | [#35](https://github.com/gtrabanco/agentic-workflow/issues/35) |
 | [39-publish-schema-oidc-403](39-publish-schema-oidc-403/SPEC.md) | `publish-schema.yml` E403 OIDC — make the failure self-serve in-repo; authorization repair is a manual npm Trusted Publisher step (blocks #38) | done · [#41](https://github.com/gtrabanco/agentic-workflow/pull/41) | — | [#39](https://github.com/gtrabanco/agentic-workflow/issues/39) |
-| [40-bump-skill-internal-only](40-bump-skill-internal-only/SPEC.md) | Reclassify `bump-skill` as internal (`user-invocable: false` + drop from plugin manifest) so the `/bump-skill` menu entry stops leaking into every consumer install; reconcile the 15+13 → 14+14 skill-count docs | pending | — | [#40](https://github.com/gtrabanco/agentic-workflow/issues/40) |
+| [40-bump-skill-internal-only](40-bump-skill-internal-only/SPEC.md) | Reclassify `bump-skill` as internal (`user-invocable: false` + drop from plugin manifest) so the `/bump-skill` menu entry stops leaking into every consumer install; reconcile the 15+13 → 14+14 skill-count docs | done | — | [#40](https://github.com/gtrabanco/agentic-workflow/issues/40) |
 
 
 ---

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -17,6 +17,7 @@ this table — history lives in git log + closed issues.
 | [33-stale-envelope-contract](33-stale-envelope-contract/SPEC.md) | Pre-feature-10 envelope contract still stated in orchestration-envelope's head + schema-package README | done | — | [#33](https://github.com/gtrabanco/agentic-workflow/issues/33) |
 | [35-single-pass-closeout-phase](35-single-pass-closeout-phase/SPEC.md) | Single-pass units drop the close-out chain — always emit a final Hardening & PR phase (≥ 2 phases) | done · [#36](https://github.com/gtrabanco/agentic-workflow/pull/36) | — | [#35](https://github.com/gtrabanco/agentic-workflow/issues/35) |
 | [39-publish-schema-oidc-403](39-publish-schema-oidc-403/SPEC.md) | `publish-schema.yml` E403 OIDC — make the failure self-serve in-repo; authorization repair is a manual npm Trusted Publisher step (blocks #38) | done · [#41](https://github.com/gtrabanco/agentic-workflow/pull/41) | — | [#39](https://github.com/gtrabanco/agentic-workflow/issues/39) |
+| [40-bump-skill-internal-only](40-bump-skill-internal-only/SPEC.md) | Reclassify `bump-skill` as internal (`user-invocable: false` + drop from plugin manifest) so the `/bump-skill` menu entry stops leaking into every consumer install; reconcile the 15+13 → 14+14 skill-count docs | pending | — | [#40](https://github.com/gtrabanco/agentic-workflow/issues/40) |
 
 
 ---

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -17,7 +17,7 @@ this table — history lives in git log + closed issues.
 | [33-stale-envelope-contract](33-stale-envelope-contract/SPEC.md) | Pre-feature-10 envelope contract still stated in orchestration-envelope's head + schema-package README | done | — | [#33](https://github.com/gtrabanco/agentic-workflow/issues/33) |
 | [35-single-pass-closeout-phase](35-single-pass-closeout-phase/SPEC.md) | Single-pass units drop the close-out chain — always emit a final Hardening & PR phase (≥ 2 phases) | done · [#36](https://github.com/gtrabanco/agentic-workflow/pull/36) | — | [#35](https://github.com/gtrabanco/agentic-workflow/issues/35) |
 | [39-publish-schema-oidc-403](39-publish-schema-oidc-403/SPEC.md) | `publish-schema.yml` E403 OIDC — make the failure self-serve in-repo; authorization repair is a manual npm Trusted Publisher step (blocks #38) | done · [#41](https://github.com/gtrabanco/agentic-workflow/pull/41) | — | [#39](https://github.com/gtrabanco/agentic-workflow/issues/39) |
-| [40-bump-skill-internal-only](40-bump-skill-internal-only/SPEC.md) | Reclassify `bump-skill` as internal (`user-invocable: false` + drop from plugin manifest) so the `/bump-skill` menu entry stops leaking into every consumer install; reconcile the 15+13 → 14+14 skill-count docs | done | — | [#40](https://github.com/gtrabanco/agentic-workflow/issues/40) |
+| [40-bump-skill-internal-only](40-bump-skill-internal-only/SPEC.md) | Reclassify `bump-skill` as internal (`user-invocable: false` + drop from plugin manifest) so the `/bump-skill` menu entry stops leaking into every consumer install; reconcile the 15+13 → 14+14 skill-count docs | done · [#45](https://github.com/gtrabanco/agentic-workflow/pull/45) | — | [#40](https://github.com/gtrabanco/agentic-workflow/issues/40) |
 
 
 ---

--- a/docs/workflow/SKILLS.md
+++ b/docs/workflow/SKILLS.md
@@ -2,14 +2,14 @@
 
 The skills that make up the agentic workflow, grouped by role.
 
-**15 user-facing skills** (one menu entry each) + **13 internal** steps composed
+**14 user-facing skills** (one menu entry each) + **14 internal** steps composed
 for you (the `plan-feature` router's two planning steps, the `review-change`
 findings engine `review-implementation`, the `orchestration-envelope` contract,
-and the workflow's own 9-skill internal review pack: `review-code`,
+the workflow's own 9-skill internal review pack: `review-code`,
 `review-security`, `review-verify`, `review-debt`, `review-design`,
-`review-a11y`, `review-brand`, `review-perf`, `review-seo`). Of the 15: 12 core
-workflow skills, a `log-session` journal helper, a `workflow-status` read-only
-sensor, and the repo-only `bump-skill` maintenance helper.
+`review-a11y`, `review-brand`, `review-perf`, `review-seo`, and the repo-only
+`bump-skill` maintenance helper). Of the 14: 12 core workflow skills, a
+`log-session` journal helper, and a `workflow-status` read-only sensor.
 
 ## Setup
 
@@ -110,7 +110,6 @@ with no arguments uses the default stated here.
 |---|---|---|
 | `audit-docs` | `/audit-docs [--fix]` | No args: report-only, findings ranked by severity. `--fix`: additionally applies the **low-risk** fixes — docs are never rewritten without it (or an explicit user go-ahead). |
 | `audit-pr` | `/audit-pr [pr-number]` | Defaults to the current branch's PR. A number targets another PR. |
-| `bump-skill` | `/bump-skill` | No arguments — detects the edited `SKILL.md` files itself. Repo-maintenance only. |
 | `design-feature` | `/design-feature <idea \| NN-slug> [instruction]` | A raw idea → interview from zero. A bare existing `NN-slug` → **review mode**: prints a summary of what the feature will do and asks what to add/remove/change. `NN-slug + instruction` → applies the change directly, no questions, scoped to the instruction. Upsert always — the only from-zero reset is an explicit "delete and redesign" in the instruction. |
 | `execute-phase` | `/execute-phase <NN> [P<k>] \| --fix <n> [P<k>] \| [--force]` | `NN` alone → single-pass (XS/S SPEC-only features). `NN P<k>` → exactly one phase of an M/L feature. `--fix <n>` → implement the fix unit `docs/fix/<n>-*`. `--force` → override the dependency/status gate (user-only escape hatch; the override is recorded in `decisions.md`; the autopilot never passes it). |
 | `generate-docs` | `/generate-docs [NN-slug \| fix-n \| path/glob] [--review]` | Scope defaults to the current branch's diff vs the default branch; a slug/fix/path narrows or redirects it. `--review` → additionally export the most recent `review-change` report as a docs page (opt-in, never automatic). |

--- a/skills/bump-skill/SKILL.md
+++ b/skills/bump-skill/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bump-skill
 user-invocable: false
-version: 2.0.0
+version: 2.1.0
 description: >
   Internal skill for the agentic-workflow repo. After editing one or more
   SKILL.md files, bumps their `version:` fields and updates every piece of

--- a/skills/bump-skill/SKILL.md
+++ b/skills/bump-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bump-skill
-user-invocable: true
+user-invocable: false
 version: 2.0.0
 description: >
   Internal skill for the agentic-workflow repo. After editing one or more


### PR DESCRIPTION
## What

Reclassifies `bump-skill` as an internal skill (`user-invocable: false`) and
drops it from the Claude Code plugin manifest, removing the `/bump-skill`
menu entry from every consumer install via both distribution channels
(the skills CLI's flag-based menu visibility, and the plugin manifest).
Reconciles the skill-count docs that assumed the old user-facing
classification (`15 user-facing + 13 internal` → `14 user-facing + 14 internal`).

## Why

`bump-skill` is repo-maintenance for `agentic-workflow` itself — its own
description already says "Internal skill for the agentic-workflow repo" —
yet it shipped `user-invocable: true`, so every `npx skills add
gtrabanco/agentic-workflow` consumer got a `/bump-skill` slash-menu entry
that does nothing for them (they aren't authoring this pack's `SKILL.md`
files or maintaining its `CHANGELOG.md`/`README.md`). It's the one skill
whose menu surface was pure noise for ~99% of installs.

## Changes

- `skills/bump-skill/SKILL.md` — `user-invocable: true` → `false`; version
  bumped `2.0.0` → `2.1.0` (minor: metadata reclassification, no behavior
  change).
- `.claude-plugin/plugin.json` — `./skills/bump-skill` removed from the
  `skills` array (28 → 27 entries).
- `docs/workflow/SKILLS.md` — removed the `/bump-skill` invocation-forms
  row; count updated to `14 user-facing + 14 internal`.
- `README.md` / `README.es.md` — both skill-count occurrences updated
  (English and Spanish).
- `CLAUDE.md` — repo-maintenance note now states `bump-skill` is
  `user-invocable: false`, invoked via the Skill tool.
- `CHANGELOG.md` / `CHANGELOG.es.md` — `bump-skill`'s per-skill history
  moved from the "Repo maintenance" subsection into "Internal
  (`user-invocable: false`)"; new `2.1.0` row added; release-log entry added.
- `docs/fix/README.md` / `docs/fix/40-bump-skill-internal-only/SPEC.md` —
  fix marked `done`.

**Out of scope** (see SPEC): physically excluding `bump-skill` from a
default `npx skills add` install (the CLI has no `--exclude`/manifest-skip
mechanism — verified impossible); rewriting historical docs that mention
running `bump-skill`; removing `bump-skill`'s `## Turn contract`/`##
Portability` sections.

## Evidence

```
$ grep -n '^user-invocable:' skills/bump-skill/SKILL.md
3:user-invocable: false

$ python3 -c "import json;d=json.load(open('.claude-plugin/plugin.json'));assert './skills/bump-skill' not in d['skills'];assert len(d['skills'])==27;print('OK')"
OK

$ grep -rn '/bump-skill' docs/workflow/SKILLS.md
(no output)

$ grep -rn '15 user-facing\|13 internal\|15 de cara al usuario\|13 internas' README.md README.es.md docs/workflow/SKILLS.md
(no output)

$ npx skills add . --list
◇  Found 28 skills
```

Closes #40
