### PR TITLE
docs(fix): drop merged fix rows #33/#35/#39/#40 from fix index

### DIFF
--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -17,7 +17,6 @@ this table — history lives in git log + closed issues.
 | [33-stale-envelope-contract](33-stale-envelope-contract/SPEC.md) | Pre-feature-10 envelope contract still stated in orchestration-envelope's head + schema-package README | done | — | [#33](https://github.com/gtrabanco/agentic-workflow/issues/33) |
 | [35-single-pass-closeout-phase](35-single-pass-closeout-phase/SPEC.md) | Single-pass units drop the close-out chain — always emit a final Hardening & PR phase (≥ 2 phases) | done · [#36](https://github.com/gtrabanco/agentic-workflow/pull/36) | — | [#35](https://github.com/gtrabanco/agentic-workflow/issues/35) |
 | [39-publish-schema-oidc-403](39-publish-schema-oidc-403/SPEC.md) | `publish-schema.yml` E403 OIDC — make the failure self-serve in-repo; authorization repair is a manual npm Trusted Publisher step (blocks #38) | done · [#41](https://github.com/gtrabanco/agentic-workflow/pull/41) | — | [#39](https://github.com/gtrabanco/agentic-workflow/issues/39) |
-| [40-bump-skill-internal-only](40-bump-skill-internal-only/SPEC.md) | Reclassify `bump-skill` as internal (`user-invocable: false` + drop from plugin manifest) so the `/bump-skill` menu entry stops leaking into every consumer install; reconcile the 15+13 → 14+14 skill-count docs | done · [#45](https://github.com/gtrabanco/agentic-workflow/pull/45) | — | [#40](https://github.com/gtrabanco/agentic-workflow/issues/40) |
 
 
 ---

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -12,12 +12,10 @@ this table — history lives in git log + closed issues.
 
 ## Active
 
-| Folder                                                                                 | Topic                                                                                         | Status    | Depends on      | Issue                                                      |
-| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | --------- | --------------- | ---------------------------------------------------------- |
-| [33-stale-envelope-contract](33-stale-envelope-contract/SPEC.md) | Pre-feature-10 envelope contract still stated in orchestration-envelope's head + schema-package README | done | — | [#33](https://github.com/gtrabanco/agentic-workflow/issues/33) |
-| [35-single-pass-closeout-phase](35-single-pass-closeout-phase/SPEC.md) | Single-pass units drop the close-out chain — always emit a final Hardening & PR phase (≥ 2 phases) | done · [#36](https://github.com/gtrabanco/agentic-workflow/pull/36) | — | [#35](https://github.com/gtrabanco/agentic-workflow/issues/35) |
-| [39-publish-schema-oidc-403](39-publish-schema-oidc-403/SPEC.md) | `publish-schema.yml` E403 OIDC — make the failure self-serve in-repo; authorization repair is a manual npm Trusted Publisher step (blocks #38) | done · [#41](https://github.com/gtrabanco/agentic-workflow/pull/41) | — | [#39](https://github.com/gtrabanco/agentic-workflow/issues/39) |
+| Folder | Topic | Status | Depends on | Issue |
+| ------ | ----- | ------ | ---------- | ----- |
 
+_No active fixes — all merged entries removed per the convention below._
 
 ---
 


### PR DESCRIPTION
## Summary

Removes **four** now-merged rows from `docs/fix/README.md`, per the file's own convention ("Entry is removed from this table on merge — do not maintain history here"). All four issues are closed and their fixes merged:

| Row dropped | Issue | Merged via |
| ----------- | ----- | ---------- |
| `33-stale-envelope-contract` | [#33](https://github.com/gtrabanco/agentic-workflow/issues/33) (CLOSED) | completed |
| `35-single-pass-closeout-phase` | [#35](https://github.com/gtrabanco/agentic-workflow/issues/35) (CLOSED) | [#36](https://github.com/gtrabanco/agentic-workflow/pull/36) (MERGED) |
| `39-publish-schema-oidc-403` | [#39](https://github.com/gtrabanco/agentic-workflow/issues/39) (CLOSED) | [#41](https://github.com/gtrabanco/agentic-workflow/pull/41) (MERGED) |
| `40-bump-skill-internal-only` | [#40](https://github.com/gtrabanco/agentic-workflow/issues/40) (CLOSED) | [#45](https://github.com/gtrabanco/agentic-workflow/pull/45) (MERGED) |

The `Active` table is now empty (header only) with a placeholder line. The SPEC folders remain on disk as reference — the convention scopes removal to the table row, not the folder.

## Why

Post-merge fix-index housekeeping the workflow requires as a separate step ("After merge only: remove the `docs/fix/README.md` entry"). The `#40` row was dropped first (commit `efffb39`); a follow-up sweep (commit `b8c2f6f`) cleared the three other stale merged rows in the same pass.

## Test plan

- [x] Docs-only change; no verification gate to run.
- [x] Verified each issue CLOSED via `gh issue view 33/35/39/40`.
- [x] Verified each fix MERGED via `gh pr view 36/41/45` (#33 closed as completed).
- [x] Grepped the repo — no other doc references the removed rows, so nothing dangles.
