### PR TITLE
docs(fix): #37 — bilingual .es.md siblings for human-readable docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,16 @@ README.md / README.es.md project overview (EN / ES)
 - **Docs language is English.** Every committed artifact (skills, docs, templates,
   commits, PR descriptions) is in English, regardless of the language used to
   request the work. Reply to the user in the user's language.
+- **Human-readable docs carry EN + ES siblings.** `README`, `CHANGELOG`,
+  `docs/workflow/*.md`, and the schema package `README` each get a faithful
+  `.es.md` sibling with reciprocal language-switcher links
+  (`> 🇪🇸 [Versión en español](<name>.es.md)` on the English original,
+  `> 🇬🇧 [English version](<name>.md)` on the Spanish sibling). Kept in sync
+  **on next touch** — whoever edits the English doc updates its Spanish
+  sibling in the same change; no automated staleness check. `SKILL.md`,
+  SPECs, commits, PRs, and machine config (`model-routing.yml`) stay
+  English-only per the rule above — this bilingual pattern applies only to
+  human tutorial/reference prose, not process artifacts.
 - **Stack/architecture agnostic.** Do not introduce references to any specific
   product, stack, framework, ORM, runtime, or architecture pattern into the
   skills or the shared docs. Generic phrasing ("the project's architecture",

--- a/README.es.md
+++ b/README.es.md
@@ -290,39 +290,64 @@ se mueve rápido; contrástalo con un leaderboard actual antes de fijar nada):
 ([catálogo completo](https://nan.builders/docs/models): GLM-5.2 ~753B MoE ·
 Mimo V2.5 310B · DeepSeek V4 Flash 284B · Qwen3.6 35B · Gemma4 26B) con toggle
 de **Thinking** y control de **effort** por petición (Minimal → Max), que mapea
-1:1 con los tiers de este workflow. Nuestros picks por skill:
-
-| Skill | Modelo NaN | Thinking | Effort |
-|---|---|---|---|
-| `init-workspace`, `plan-feature`, `plan-fix`, `review-change`, `audit-pr`, `triage-issue` | **GLM-5.2** | on | High |
-| `product-audit` | **GLM-5.2** | on | **Max** |
-| `ship-roadmap` (conductor) | **GLM-5.2** | on | High |
-| `execute-phase` (+ la ejecución de ship-roadmap), `audit-docs`, `bump-skill`, `workflow-status` | **Qwen3.6** | off | Medium |
-| `log-session`, recolección de evidencia | **DeepSeek V4 Flash** | off | Low |
-
-Alternativas: lógica de implementación sutil → sube `execute-phase` a
-GLM-5.2/High; **Mimo V2.5** (familia distinta) revisando código escrito por
-Qwen añade independencia del revisor; **Gemma4** vale para el tier pequeño.
-Whisper, Kokoro, Rerank, Qwen3 Embedding y Flux 2 Klein son modelos de
-audio/retrieval/imagen — el workflow no los usa. Regístrate con
+1:1 con los tiers de este workflow. Regístrate con
 [este enlace de referido](https://cloud.nan.builders/r/7GK06FX8).
 
-**Si GLM-5.2 está caído — escalera de fallback:**
+**Dos perfiles, no un solo principal.** GLM-5.2 ya no está disponible en el
+plan básico — es el principal del **plan de €200** (prácticamente ilimitado
+ahí; los límites solo aprietan con uso muy intensivo). En el **plan básico**
+simplemente no está disponible, así que los picks de abajo se dividen en una
+columna para el plan de €200 y una escalera para el plan básico.
 
-| # | Fallback | Config | Vale para | Nunca para |
+**Regla de enrutamiento consciente de la cuota.** Según el catálogo, solo
+**Mimo V2.5** y **DeepSeek V4 Flash** llevan un límite explícito (500M
+tok/miembro/mes); **Qwen3.6** y **Gemma4** no muestran límite listado (256K
+de contexto — "sin límite listado" se trata como *no confirmado*, nunca se
+afirma como ilimitado). Reserva los dos presupuestos de 500M con límite para
+trabajo de 1M de contexto y veredictos que gatean merges; empuja el volumen
+re-comprobable y mecánico hacia los modelos sin límite en su lugar.
+
+**Escaleras de preferencia por tarea** (2–3 niveles en el plan básico; el
+plan de €200 simplemente corre GLM-5.2 en todas partes):
+
+| Tarea | Skills | Plan de €200 | Escalera del plan básico | Nunca aquí |
 |---|---|---|---|---|
-| 1 | **Mimo V2.5** (310B, reasoning, 1M ctx) | Thinking on, High (Max para `product-audit`) | **todos** los huecos de GLM-5.2, incluidos `audit-pr` y `product-audit`; como revisor de familia cruzada incluso añade independencia | — |
-| 2 | **Qwen3.6** (35B) | Thinking on, High | `plan-feature`, `plan-fix`, `init-workspace`, `triage-issue`, conductor de `ship-roadmap` — su salida la re-comprueban después revisión y auditoría | `audit-pr` · `product-audit` · revisar código que el propio Qwen3.6 escribió (el ≥ se cumple, la independencia no) |
-| 3 | **DeepSeek V4 Flash** (284B·21B activos) | Thinking on, High | planificación/triage de último recurso si 1–2 caen | cualquier veredicto que gatee un merge |
-| — | **Gemma4** (26B) | — | solo tier pequeño mecánico | juicio, jamás |
+| **Puertas de merge** | `audit-pr`, `product-audit` | GLM-5.2, Thinking on, High (Max para `product-audit`) | 1. **Mimo V2.5** (Max) → 2. **DeepSeek V4 Flash** (suelo) → si no, **pospón al humano** | Qwen3.6, Gemma4 |
+| **Planificación / enrutamiento / triage** | `plan-feature`, `plan-fix`, `init-workspace`, `triage-issue`, `review-change`, conductor de `ship-roadmap` | GLM-5.2, Thinking on, High | 1. **Qwen3.6** (ahorra cuota) → 2. **Mimo V2.5** → 3. **DeepSeek V4 Flash** | — |
+| **Ejecución / mecánico** | `execute-phase`, `audit-docs`, `bump-skill`, `workflow-status` | Qwen3.6, Thinking off, Medium | 1. **Qwen3.6** → 2. **Gemma4** → 3. **DeepSeek V4 Flash** | — |
+| **Barato** | `log-session`, recolección de evidencia | DeepSeek V4 Flash, Thinking off, Low | 1. **DeepSeek V4 Flash** → 2. **Qwen3.6** → 3. **Gemma4** | — |
+| **Incorporar hallazgos de `review-change`/`audit-pr`** | ciclo de incorporación de `execute-phase` | según el hallazgo (ver abajo) | hallazgo **rutinario/mecánico** (estilo, stub de test faltante, doc obsoleto) → igual que Ejecución/mecánico; hallazgo **sutil** (lógica, seguridad, arquitectura) → sube al tier que lo encontró (escalera de Puertas de merge o de Planificación/enrutamiento, la que haya corrido la revisión) | — |
 
-**Los dos veredictos que gatean merges solo corren con calidad de tier 1:**
-`audit-pr` y `product-audit` pueden caer a **Mimo V2.5** (effort Max), pero
-nunca más abajo — un barrido en un modelo medio devuelve un informe
-*aparentemente completo pero superficial*, peor que ningún informe. ¿GLM-5.2
-**y** Mimo V2.5 caídos a la vez? → pospón: el humano gatea el merge a mano y el
-product-audit espera. Todo lo que ya corre en los tiers Qwen3.6/Flash no se ve
-afectado por una caída de GLM-5.2.
+La fila del ciclo de incorporación reemplaza a la antigua línea de
+"Alternativas" de un solo modelo (que solo nombraba a GLM-5.2 para subidas
+de lógica sutil). Regla general: el modelo que arregla nunca es más débil
+que el que escribió el código original, ni más débil de lo que exige la
+sutileza del hallazgo — de lo contrario el propio arreglo necesita
+volver a atraparse en la re-revisión, desperdiciando un ciclo.
+
+**Advertencia de razonamiento de `Qwen3.6`, explícita:** aceptable solo para
+razonamiento **re-comprobado** (salida de planificación/enrutamiento/triage
+que revisión o auditoría verifica después) — nunca un veredicto que gatee
+un merge (3B de parámetros activos → una auditoría plausible-pero-superficial
+es peor que ninguna). En el plan básico, una vez gastada la cuota de Mimo
+V2.5 + DeepSeek V4 Flash, no queda ningún razonador fuerte → pospón al
+humano, espera al reinicio de la cuota, o sube al plan de €200.
+
+**Pros y contras por modelo:**
+
+| Modelo | Tamaño | Contexto | Cuota en plan básico | Bueno para | Evitar para |
+|---|---|---|---|---|---|
+| **GLM-5.2** | ~753B MoE | — | No disponible en el plan básico (solo plan de €200, prácticamente ilimitado ahí) | Cualquier hueco de juicio, cuando está disponible | — |
+| **Mimo V2.5** | 310B, reasoning | 1M ctx | 500M tok/miembro/mes | Puertas de merge + trabajo de contexto largo; familia distinta a Qwen3.6, así que añade independencia de revisor | — |
+| **DeepSeek V4 Flash** | 284B total · 21B activos | — | 500M tok/miembro/mes | Volumen barato/mecánico; suelo de último recurso para planificación/triage cuando 1–2 de arriba están gastados | Cualquier veredicto que gatee un merge |
+| **Qwen3.6** | 35B | 256K ctx | sin límite listado | Planificación/enrutamiento/triage (re-comprobado después); ejecución mecánica | Veredictos que gatean merges; revisar código que él mismo escribió |
+| **Gemma4** | 26B | 256K ctx | sin límite listado | Solo tier pequeño mecánico | Cualquier llamada de juicio |
+
+Whisper, Kokoro, Rerank, Qwen3 Embedding y Flux 2 Klein son modelos de
+audio/retrieval/imagen — el workflow no los usa. La fuerza de los modelos de
+arriba se enmarca por parámetros activos + rol, no por números de
+benchmark — verifica contra un leaderboard actual antes de fijar; este
+panorama cambia rápido.
 
 **¿Ya estás en la rama por defecto (o en `#inheritance`)?** No hay nada que
 quitar — es justo el punto. Cada skill ya **hereda el modelo y esfuerzo de tu

--- a/README.md
+++ b/README.md
@@ -281,37 +281,60 @@ fast; sanity-check against a current leaderboard before pinning):
 frontier ([full catalog](https://nan.builders/docs/models): GLM-5.2 ~753B MoE ·
 Mimo V2.5 310B · DeepSeek V4 Flash 284B · Qwen3.6 35B · Gemma4 26B) with
 per-request **Thinking** toggle and **effort** control (Minimal → Max), which
-maps 1:1 onto this workflow's tiers. Our picks per skill:
+maps 1:1 onto this workflow's tiers. Sign up via
+[this referral link](https://cloud.nan.builders/r/7GK06FX8).
 
-| Skill | NaN model | Thinking | Effort |
-|---|---|---|---|
-| `init-workspace`, `plan-feature`, `plan-fix`, `review-change`, `audit-pr`, `triage-issue` | **GLM-5.2** | on | High |
-| `product-audit` | **GLM-5.2** | on | **Max** |
-| `ship-roadmap` (conductor) | **GLM-5.2** | on | High |
-| `execute-phase` (+ ship-roadmap's execution runs), `audit-docs`, `bump-skill`, `workflow-status` | **Qwen3.6** | off | Medium |
-| `log-session`, evidence gathering | **DeepSeek V4 Flash** | off | Low |
+**Two profiles, not one primary.** GLM-5.2 is no longer available on the
+basic plan — it's the **€200-plan** primary (practically unlimited there;
+caps only bite very heavy use). On the **basic plan** it's simply
+unavailable, so the picks below split into an €200-plan column and a
+basic-plan ladder.
 
-Alternates: subtle implementation logic → bump `execute-phase` to GLM-5.2/High;
-**Mimo V2.5** (a different family) reviewing Qwen-written code adds reviewer
-independence; **Gemma4** swaps into the small tier. Whisper, Kokoro, Rerank,
-Qwen3 Embedding and Flux 2 Klein are audio/retrieval/image models — not used by
-the workflow. Sign up via [this referral link](https://cloud.nan.builders/r/7GK06FX8).
+**Quota-aware routing rule.** Per the catalog, only **Mimo V2.5** and
+**DeepSeek V4 Flash** carry an explicit cap (500M tok/member/mo); **Qwen3.6**
+and **Gemma4** show no listed cap (256K ctx — "no cap listed" is treated as
+*unconfirmed*, never asserted as unlimited). Reserve the two capped 500M
+budgets for 1M-context work and merge-gating verdicts; push re-checkable and
+mechanical volume onto the uncapped models instead.
 
-**If GLM-5.2 is down — fallback ladder:**
+**Preference ladders per task** (2–3 deep on the basic plan; the €200 plan
+just runs GLM-5.2 everywhere):
 
-| # | Fallback | Config | Good for | Never for |
+| Task | Skills | €200 plan | Basic-plan ladder | Never here |
 |---|---|---|---|---|
-| 1 | **Mimo V2.5** (310B, reasoning, 1M ctx) | Thinking on, High (Max for `product-audit`) | **every** GLM-5.2 slot, including `audit-pr` and `product-audit`; as a cross-family reviewer it even adds independence | — |
-| 2 | **Qwen3.6** (35B) | Thinking on, High | `plan-feature`, `plan-fix`, `init-workspace`, `triage-issue`, `ship-roadmap` conductor — their output is re-checked downstream by review/audit | `audit-pr` · `product-audit` · reviewing code Qwen3.6 itself wrote (≥ holds, independence doesn't) |
-| 3 | **DeepSeek V4 Flash** (284B·21B active) | Thinking on, High | last-resort planning/triage when 1–2 are down | any verdict that gates a merge |
-| — | **Gemma4** (26B) | — | small mechanical tier only | judgment, ever |
+| **Merge gates** | `audit-pr`, `product-audit` | GLM-5.2, Thinking on, High (Max for `product-audit`) | 1. **Mimo V2.5** (Max) → 2. **DeepSeek V4 Flash** (floor) → else **defer to the human** | Qwen3.6, Gemma4 |
+| **Planning / routing / triage** | `plan-feature`, `plan-fix`, `init-workspace`, `triage-issue`, `review-change`, `ship-roadmap` conductor | GLM-5.2, Thinking on, High | 1. **Qwen3.6** (quota-saver) → 2. **Mimo V2.5** → 3. **DeepSeek V4 Flash** | — |
+| **Execution / mechanical** | `execute-phase`, `audit-docs`, `bump-skill`, `workflow-status` | Qwen3.6, Thinking off, Medium | 1. **Qwen3.6** → 2. **Gemma4** → 3. **DeepSeek V4 Flash** | — |
+| **Cheap** | `log-session`, evidence gathering | DeepSeek V4 Flash, Thinking off, Low | 1. **DeepSeek V4 Flash** → 2. **Qwen3.6** → 3. **Gemma4** | — |
+| **Folding `review-change`/`audit-pr` findings** | `execute-phase`'s fold cycle | per finding (see below) | **routine/mechanical** finding (style, missing test stub, stale doc) → same as Execution/mechanical; **subtle** finding (logic, security, architecture) → bump to the tier that found it (Merge-gates or Planning/routing ladder, whichever review ran) | — |
 
-**The two merge-gating verdicts only run on tier 1 quality:** `audit-pr` and
-`product-audit` may fall back to **Mimo V2.5** (Max effort), but never further
-down — a mid-model sweep returns a *plausible-looking but shallow* report,
-worse than no report. Both GLM-5.2 **and** Mimo V2.5 down → defer: the human
-gates the merge manually, the product audit waits. Everything already at the
-Qwen3.6/Flash tiers is unaffected by a GLM-5.2 outage.
+The fold-cycle row supersedes the old single-model "Alternates" line (which
+only named GLM-5.2 for subtle-logic bumps). Rule of thumb: the fixing model
+is never weaker than the one that wrote the original code, and never weaker
+than the finding's subtlety warrants — otherwise the fix itself needs
+re-catching on re-review, wasting a cycle.
+
+**`Qwen3.6` reasoning caveat, stated explicitly:** acceptable only for
+**re-checked** reasoning (planning/routing/triage output that review or audit
+verifies downstream) — never a merge-gating verdict (3B active parameters → a
+plausible-but-shallow audit is worse than none). On the basic plan, once the
+Mimo V2.5 + DeepSeek V4 Flash quota is spent, no strong reasoner remains →
+defer to the human, wait for the quota reset, or upgrade to the €200 plan.
+
+**Per-model pros/cons:**
+
+| Model | Size | Context | Basic-plan quota | Good for | Avoid for |
+|---|---|---|---|---|---|
+| **GLM-5.2** | ~753B MoE | — | Unavailable on the basic plan (€200-plan only, practically unlimited there) | Every judgment slot, when available | — |
+| **Mimo V2.5** | 310B, reasoning | 1M ctx | 500M tok/member/mo | Merge gates + long-context work; a different family from Qwen3.6, so it adds reviewer independence | — |
+| **DeepSeek V4 Flash** | 284B total · 21B active | — | 500M tok/member/mo | Cheap/mechanical volume; last-resort planning/triage floor when 1–2 above are spent | Any verdict that gates a merge |
+| **Qwen3.6** | 35B | 256K ctx | no cap listed | Planning/routing/triage (re-checked downstream); mechanical execution | Merge-gating verdicts; reviewing code it wrote itself |
+| **Gemma4** | 26B | 256K ctx | no cap listed | Small mechanical tier only | Any judgment call |
+
+Whisper, Kokoro, Rerank, Qwen3 Embedding and Flux 2 Klein are
+audio/retrieval/image models — not used by the workflow. Model strength above
+is framed by active-params + role, not benchmark numbers — sanity-check
+against a current leaderboard before pinning; this landscape moves fast.
 
 **Already on the default branch (or `#inheritance`)?** No pinning to remove —
 that's the point. Every skill already **inherits your session's model and

--- a/docs/fix/37-bilingual-human-docs/SPEC.md
+++ b/docs/fix/37-bilingual-human-docs/SPEC.md
@@ -127,6 +127,18 @@ new shape:
     `workflow-status`): 1. Qwen3.6 → 2. Gemma4 → 3. DeepSeek V4 Flash.
   - *Cheap* (`log-session`, evidence): 1. DeepSeek V4 Flash → 2. Qwen3.6
     → 3. Gemma4.
+  - *Folding `review-change`/`audit-pr` findings back into the branch*
+    (`execute-phase`'s fold cycle): **routine/mechanical** findings (style,
+    missing test stub, stale doc) → same as Execution/mechanical above
+    (Qwen3.6 → Gemma4 → DeepSeek V4 Flash); **subtle** findings (logic,
+    security, architecture — the kind a weak model wouldn't have caught in
+    the first place) → bump to the tier that found them (Merge-gates or
+    Planning/routing ladder, whichever review ran). Rule of thumb: the
+    fixing model is never weaker than the one that wrote the original
+    code, and never weaker than warranted by the finding's subtlety —
+    otherwise the fix itself needs re-catching on re-review, wasting a
+    cycle. Supersedes the current single-model "Alternates" line
+    (`README.md`, subtle-logic bump) which only names GLM-5.2.
 - **`Qwen3.6` reasoning caveat, stated explicitly:** acceptable only for
   **re-checked** reasoning; never a merge-gating verdict (3B active → a
   plausible-but-shallow audit is worse than none). On the basic plan, once
@@ -362,9 +374,12 @@ literal `Hardening & PR` close-out.
       quota-aware shape specified in Scope → Model-routing revision:
       GLM-5.2 = €200-plan option (not the basic-plan primary); quota-aware
       routing rule; per-task preference ladders (2–3 deep) with config +
-      pro/con; the "never Qwen3.6 for merge gates / defer to human" rule;
-      the 5-model pros/cons table. No unverified benchmark numbers; keep
-      the "sanity-check against a current leaderboard" caveat.
+      pro/con, **including the fold-cycle ladder** (routine finding →
+      execution tier; subtle finding → bump to the tier that found it,
+      superseding the old single-model "Alternates" line); the "never
+      Qwen3.6 for merge gates / defer to human" rule; the 5-model pros/cons
+      table. No unverified benchmark numbers; keep the "sanity-check
+      against a current leaderboard" caveat.
 - [ ] `README.es.md`: mirror the **same** revised section as a faithful
       Spanish translation — identical ladders, config values, model names,
       and table rows; no divergence from `README.md`.

--- a/docs/fix/37-bilingual-human-docs/SPEC.md
+++ b/docs/fix/37-bilingual-human-docs/SPEC.md
@@ -19,6 +19,16 @@ language-neutral across any project this pack installs into — not human
 tutorial/reference prose explaining the repo to a reader. The fix also
 records a lightweight go-forward convention so the pattern stays coherent.
 
+**Folded in (owner decision, 2026-07-12):** the README's model-routing
+recommendation (`README.md` + `README.es.md`, the "Running on NaN.builders"
+section + fallback ladder) is revised in the same fix. `GLM-5.2` is no
+longer available on the basic plan — it stays in the docs but repositioned
+as the **€200-plan** primary (practically unlimited there); for the
+majority on the basic plan it is **not** the primary. The section is
+restructured into quota-aware, 2–3-deep preference ladders per task with
+per-model pros/cons. The owner chose to carry this in `#37` rather than a
+separate issue/fix (see "Decisions made during drafting").
+
 ## Issue
 
 `#37` — GitHub issue. The PR must close it via `Closes #37` in the body.
@@ -49,7 +59,9 @@ recorded scope decision either way, so the gap persisted silently.
 User conversation, 2026-07-11 — noticed while asking about
 `docs/workflow/GOLDEN_FIXTURE.md`. Owner comment (2026-07-11) added
 `packages/agentic-workflow-schema/README.md` to scope, to translate after
-`#44` landed there.
+`#44` landed there. Conversation 2026-07-12: owner reported `GLM-5.2` left
+the basic plan (returns on a forthcoming €200 plan) and folded the
+model-routing recommendation revision into this fix.
 
 ## Scope
 
@@ -83,10 +95,48 @@ doc, and record the go-forward convention.
   here (e.g. `model-routing.yml`, `SKILL.md` paths, `docs/features/`,
   `docs/fix/`) keep their existing English target.
 
-**Convention (P5):** record in `CLAUDE.md` that human-readable docs carry
+**Convention (P6):** record in `CLAUDE.md` that human-readable docs carry
 EN + ES siblings, kept in sync **on next touch** (no automated
 bookkeeping), while `SKILL.md`, SPECs, commits, PRs, and machine config
 stay English-only.
+
+**Model-routing revision (P5) — `README.md` + `README.es.md`, the
+"Running on NaN.builders" section + "If GLM-5.2 is down" fallback ladder.**
+Same content change applied to EN, then mirrored into the ES sibling. The
+new shape:
+
+- **Two profiles, not one primary.** `GLM-5.2` stays listed but as the
+  **€200-plan** primary (practically unlimited there; caps only bite very
+  heavy use). On the basic plan it is **unavailable** → for most users it
+  is not the primary.
+- **Quota-aware routing rule.** Only `Mimo V2.5` and `DeepSeek V4 Flash`
+  carry an explicit cap (500M tok/member/mo per the catalog); `Qwen3.6` /
+  `Gemma4` show no listed cap (256K ctx). Reserve the capped 500M budgets
+  for 1M-context work and merge-gating verdicts; push re-checkable and
+  mechanical volume onto the uncapped models.
+- **Preference ladders (2–3 deep) per task**, each entry with config
+  (Thinking/effort) and a one-line pro/con:
+  - *Merge gates* (`audit-pr`, `product-audit`): €200 → GLM-5.2 High/Max;
+    basic → 1. Mimo V2.5 → 2. DeepSeek V4 Flash (floor) → else **defer to
+    the human**. **Never** Qwen3.6/Gemma4 here.
+  - *Planning/routing/triage* (`plan-feature`, `plan-fix`,
+    `init-workspace`, `triage-issue`, `review-change`, `ship-roadmap`
+    conductor — re-checked downstream): €200 → GLM-5.2; basic → 1. Qwen3.6
+    (quota-saver) → 2. Mimo V2.5 → 3. DeepSeek V4 Flash.
+  - *Execution/mechanical* (`execute-phase`, `audit-docs`, `bump-skill`,
+    `workflow-status`): 1. Qwen3.6 → 2. Gemma4 → 3. DeepSeek V4 Flash.
+  - *Cheap* (`log-session`, evidence): 1. DeepSeek V4 Flash → 2. Qwen3.6
+    → 3. Gemma4.
+- **`Qwen3.6` reasoning caveat, stated explicitly:** acceptable only for
+  **re-checked** reasoning; never a merge-gating verdict (3B active → a
+  plausible-but-shallow audit is worse than none). On the basic plan, once
+  Mimo + DeepSeek quota is spent, no strong reasoner remains → defer to
+  human, wait for reset, or upgrade to the €200 plan.
+- **Per-model pros/cons table** covering all five (GLM-5.2, Mimo V2.5,
+  DeepSeek V4 Flash, Qwen3.6, Gemma4).
+- **No unverified benchmark claims.** Model strength is framed by
+  active-params + role, not invented leaderboard numbers; the existing
+  "sanity-check against a current leaderboard" caveat stays.
 
 ### Out of scope
 
@@ -124,6 +174,14 @@ in brackets (this repo has no application build — see CLAUDE.md
       `README.es.md`, and `npm test` in that package passes. [package test]
 - [ ] `CLAUDE.md` documents the EN+ES human-doc convention and its "on next
       touch" (no-tooling) sync policy. [file-content]
+- [ ] `README.md` model-routing section is restructured: GLM-5.2 shown as
+      the €200-plan option (not the basic-plan primary), quota-aware rule
+      stated, per-task preference ladders (2–3 deep) with config + pro/con,
+      the "never Qwen3.6 for merge gates / defer to human" rule, and a
+      5-model pros/cons table. [file-content]
+- [ ] `README.es.md` carries the **same** restructured section, a faithful
+      translation of the revised `README.md` content (no divergence in the
+      ladders, config values, or model names). [manual review — EN/ES parity]
 - [ ] `docs/fix/README.md` row for this fix reaches `done`. [file-content]
 
 **Manual verification required (why):** translation fidelity and Spanish
@@ -134,16 +192,19 @@ sections, no invented content, no mistranslated technical claims).
 ## Impact
 
 - **Layers touched:** documentation only (`docs/workflow/`,
-  `packages/agentic-workflow-schema/`) + repo guidance (`CLAUDE.md`) + one
-  package-manifest field (`package.json` `files`). No skills, no schema,
-  no runtime code.
+  `packages/agentic-workflow-schema/`, `README.md` + `README.es.md`) + repo
+  guidance (`CLAUDE.md`) + one package-manifest field (`package.json`
+  `files`). No skills, no schema, no runtime code.
 - **Modules/files:** 12 new `.es.md`; 12 English docs edited (forward-link
-  only); `packages/agentic-workflow-schema/package.json`; `CLAUDE.md`;
-  `docs/fix/README.md`.
+  only); `README.md` + `README.es.md` (model-routing section rewritten —
+  content, not a forward-link); `packages/agentic-workflow-schema/package.json`;
+  `CLAUDE.md`; `docs/fix/README.md`.
 - **Blast radius:** dev-/reader-facing only. Worst realistic failure is a
-  broken relative link or a mistranslation — no data, no behavior, no
-  security surface. A wrong `files` entry could omit `README.es.md` from
-  the published package (caught by the acceptance check + `npm pack`).
+  broken relative link, a mistranslation, or a **stale/incorrect model
+  recommendation** (a reader picks a model for a merge gate that the doc
+  should have barred) — no data, no behavior, no security surface. A wrong
+  `files` entry could omit `README.es.md` from the published package
+  (caught by the acceptance check + `npm pack`).
 - **Detection lead time:** immediate at review (link check + manual
   read); a stale/omitted translation surfaces only when a Spanish reader
   hits it — hence the recorded on-next-touch convention.
@@ -155,7 +216,11 @@ sections, no invented content, no mistranslated technical claims).
   rules"). This fix translates *human docs*, never those.
 - **Stack/architecture-agnostic.** No product/stack/framework/ORM/runtime/
   architecture reference may be introduced into the translated docs
-  (CLAUDE.md "Working rules").
+  (CLAUDE.md "Working rules"). The model-routing revision stays inside
+  `README.md`/`README.es.md`'s existing "Concrete picks / Running on
+  NaN.builders" section — the doc's already-designated place for concrete,
+  non-agnostic model recommendations — so it introduces no product
+  reference into `skills/` or the shared workflow docs.
 - **Schema mirror rule.** If `packages/agentic-workflow-schema/` is
   touched, `npm test` passes there; **any envelope-schema change** must be
   mirrored in types + `envelope.schema.json` + version bump, same PR. This
@@ -193,6 +258,9 @@ Acceptance), not a side update:
 
 - All 11 `docs/workflow/*.md` (new `.es.md` + forward-link on the EN doc).
 - `packages/agentic-workflow-schema/README.md` (new `.es.md` + `files`).
+- `README.md` + `README.es.md` — model-routing section rewritten
+  (GLM-5.2 → €200-plan; quota-aware per-task ladders; 5-model pros/cons),
+  EN then mirrored to ES.
 - `CLAUDE.md` — new bilingual human-doc convention (section under "Working
   rules").
 
@@ -214,19 +282,29 @@ design; the on-next-touch convention in `CLAUDE.md` is the only guard.
   `files`; does not block this fix and this fix does not block it.
 - No open issue overlaps, absorbs, or is absorbed by this fix (`#37` is
   the only other open issue — this one).
+- **Model-routing revision — no separate issue.** The GLM-5.2
+  plan-availability change (basic → €200 plan) would normally be its own
+  fix/issue (different files, editorial content vs. translation). The owner
+  explicitly directed (2026-07-12) that it ride in `#37` with no new issue;
+  the PR's `Closes #37` therefore also carries this documented,
+  out-of-title change. Recorded here so the SPEC — not silent drift — is
+  the source of truth.
 
 ## Effort
 
-**L** (multi-commit, > 1 day-equivalent) — ~90 KB of prose across 12 files
-plus 12 forward-link edits, a manifest change, and a convention note.
+**L** (multi-commit, > 1 day-equivalent) — ~90 KB of prose across 12 files,
+12 forward-link edits, a manifest change, a convention note, **plus** the
+model-routing section rewrite in two files (the one genuinely editorial
+piece).
 
 The `plan-fix` guidance says an L item may be escalated to a feature via
-`plan-feature` — **the user decides at review**. Recommendation: keep it as
-this phased fix. The work is mechanical translation with **zero open design
-decisions**, cleanly partitioned by document cluster; the `## Phases`
-ledger already sequences it into checkable multi-commit units, which is
-exactly what `execute-phase --fix` runs. A feature SPEC would add planning
-overhead without adding design content.
+`plan-feature` — **the user decides**; the owner has decided to keep it as
+this phased fix (and to fold the model-routing change in). All but one
+phase is mechanical translation; the single design-bearing piece
+(model-routing, P5) is fully specified above (ladders, config, rules), so
+no open design decision remains for the executor. The `## Phases` ledger
+sequences everything into checkable multi-commit units, which is exactly
+what `execute-phase --fix` runs.
 
 ## Phases
 
@@ -271,7 +349,24 @@ literal `Hardening & PR` close-out.
 - [ ] Gate: `npm test` in the package passes; `npm pack --dry-run` lists
       `README.es.md`; relative links resolve.
 
-### P5 — Sync-policy convention
+### P5 — Model-routing recommendation revision
+
+- [ ] `README.md`: rewrite the "Running on NaN.builders" section + the
+      "If GLM-5.2 is down" fallback ladder into the two-profile,
+      quota-aware shape specified in Scope → Model-routing revision:
+      GLM-5.2 = €200-plan option (not the basic-plan primary); quota-aware
+      routing rule; per-task preference ladders (2–3 deep) with config +
+      pro/con; the "never Qwen3.6 for merge gates / defer to human" rule;
+      the 5-model pros/cons table. No unverified benchmark numbers; keep
+      the "sanity-check against a current leaderboard" caveat.
+- [ ] `README.es.md`: mirror the **same** revised section as a faithful
+      Spanish translation — identical ladders, config values, model names,
+      and table rows; no divergence from `README.md`.
+- [ ] Gate: EN and ES model tables/ladders match 1:1 (diff the two
+      sections); all links in both still resolve; no invented benchmark
+      claim introduced.
+
+### P6 — Sync-policy convention
 
 - [ ] `CLAUDE.md`: under "Working rules", record that **human-readable
       docs** (`README`, `CHANGELOG`, `docs/workflow/*.md`, the schema
@@ -282,7 +377,7 @@ literal `Hardening & PR` close-out.
 - [ ] Gate: `CLAUDE.md` still links resolve; wording is generic (no
       stack/project reference).
 
-### P6 — Hardening & PR
+### P7 — Hardening & PR
 
 - [ ] Re-run the project's full verification gate (commands + exit codes pasted)
 - [ ] Pending-docs check: `git status --porcelain -- docs/` → empty
@@ -304,6 +399,12 @@ No unit/integration layer applies (documentation). Verification is:
    (P4), plus `npm pack --dry-run` to confirm `README.es.md` is packaged.
 3. **Manual review** — a fluent reader spot-checks translation fidelity
    (mandatory; not automatable).
+4. **Model-routing parity + correctness** (P5) — diff the `README.md` and
+   `README.es.md` model sections (ladders/config/names/table must match
+   1:1); confirm the recommendation logic is present (GLM-5.2 = €200-plan,
+   never Qwen3.6 for merge gates, defer-to-human when both capped models
+   are spent). Correctness of the recommendation is a manual judgement, not
+   an automatable gate.
 
 Existing tests at regression risk: none — no code path changes; the schema
 package test only re-runs to confirm the manifest edit is inert.
@@ -337,5 +438,22 @@ translations themselves (recoverable from git history).
   existing root-`README.md` pattern — the `docs/workflow/*.md` files have
   none today, so establishing the pair edits both sides.
 - **Phase grouping by document cluster** (flow / reference / replication /
-  schema / policy) rather than one phase per file — keeps each phase a
-  single coherent concern while staying independently checkable.
+  schema / model-routing / policy) rather than one phase per file — keeps
+  each phase a single coherent concern while staying independently
+  checkable.
+- **Model-routing revision folded into `#37`, no separate issue** — owner
+  instruction (2026-07-12), overriding the default one-PR-per-unit /
+  track-don't-inline discipline (flagged at the time, waived by the owner).
+  Reflected in the SPEC so scope stays explicit rather than drifting.
+- **GLM-5.2 repositioned, not removed** — it stays in the docs as the
+  €200-plan primary (owner: practically unlimited there, limits only for
+  very heavy use); the basic-plan default becomes the quota-aware fleet.
+- **Quota-aware routing** — grounded in the nan.builders catalog
+  (2026-07-12 fetch): only Mimo V2.5 and DeepSeek V4 Flash show a 500M
+  tok/member cap; GLM-5.2/Qwen3.6/Gemma4 show none. "No cap listed" is
+  treated as *unconfirmed, not unlimited* — the doc must not assert
+  unlimited without the plan terms.
+- **Qwen3.6 = re-checkable reasoning only** — reasoned from active-params
+  (35B/3B) + role, not a live benchmark; never a merge-gating verdict;
+  both capped models spent ⇒ defer to human. No invented benchmark numbers
+  enter the doc (the leaderboard-sanity-check caveat stays).

--- a/docs/fix/37-bilingual-human-docs/SPEC.md
+++ b/docs/fix/37-bilingual-human-docs/SPEC.md
@@ -372,12 +372,14 @@ literal `Hardening & PR` close-out.
 
 ### P4 — Schema package API reference → ES
 
-- [ ] `packages/agentic-workflow-schema/README.es.md` — faithful
+- [x] `packages/agentic-workflow-schema/README.es.md` — faithful
       translation + back-link; add forward-link to the package `README.md`.
-- [ ] Add `"README.es.md"` to the `files` array in
+- [x] Add `"README.es.md"` to the `files` array in
       `packages/agentic-workflow-schema/package.json`.
-- [ ] Gate: `npm test` in the package passes; `npm pack --dry-run` lists
-      `README.es.md`; relative links resolve.
+- [x] Gate: `npm test` in the package passes (13/13); `npm pack --dry-run`
+      lists `README.es.md` (11.9kB, 7 total files); relative links
+      resolve; no stack/real-project leak; `npx skills add . --list`
+      still green.
 
 ### P5 — Model-routing recommendation revision
 

--- a/docs/fix/37-bilingual-human-docs/SPEC.md
+++ b/docs/fix/37-bilingual-human-docs/SPEC.md
@@ -429,11 +429,14 @@ literal `Hardening & PR` close-out.
       across every phase.)
 - [x] Pending-docs check: `git status --porcelain -- docs/` → empty
 - [x] Set the fix-index row status to `done` and commit the flip
-- [ ] `git push`
-- [ ] Open the PR (`gh pr create --body-file <path>` — body written as a
+- [x] `git push`
+- [x] Open the PR (`gh pr create --body-file <path>` — body written as a
       Markdown file, real backticks, never inline `--body`/heredoc) and
       PRINT THE PR URL in the chat; the body includes `Closes #37`
-- [ ] Update the fix-index row to `done · [#<pr>](<pr-url>)`
+      (PR: https://github.com/gtrabanco/agentic-workflow/pull/50 — body
+      verified with `gh pr view 50 --json body`, backticks render
+      correctly, no literal `\`` escapes.)
+- [x] Update the fix-index row to `done · [#<pr>](<pr-url>)`
 - [ ] Commit `docs: link PR #37` and push
 
 ## Testing

--- a/docs/fix/37-bilingual-human-docs/SPEC.md
+++ b/docs/fix/37-bilingual-human-docs/SPEC.md
@@ -421,9 +421,14 @@ literal `Hardening & PR` close-out.
 
 ### P7 — Hardening & PR
 
-- [ ] Re-run the project's full verification gate (commands + exit codes pasted)
-- [ ] Pending-docs check: `git status --porcelain -- docs/` → empty
-- [ ] Set the fix-index row status to `done` and commit the flip
+- [x] Re-run the project's full verification gate (commands + exit codes pasted)
+      (`npx skills add . --list` exit 0; `npm test` in
+      `packages/agentic-workflow-schema` 13/13 pass; full link-resolution
+      sweep across all 12 new `.es.md` + `README.md`/`README.es.md`/
+      `CLAUDE.md` — 0 broken; no stack/real-project leak grep-checked
+      across every phase.)
+- [x] Pending-docs check: `git status --porcelain -- docs/` → empty
+- [x] Set the fix-index row status to `done` and commit the flip
 - [ ] `git push`
 - [ ] Open the PR (`gh pr create --body-file <path>` — body written as a
       Markdown file, real backticks, never inline `--body`/heredoc) and
@@ -461,7 +466,7 @@ translations themselves (recoverable from git history).
 
 ## Status
 
-`pending`
+`done`
 
 ## Decisions made during drafting
 

--- a/docs/fix/37-bilingual-human-docs/SPEC.md
+++ b/docs/fix/37-bilingual-human-docs/SPEC.md
@@ -344,11 +344,16 @@ literal `Hardening & PR` close-out.
 
 ### P2 — Skill & review reference → ES
 
-- [ ] `docs/workflow/SKILLS.es.md` — translation + back-link; forward-link on EN.
-- [ ] `docs/workflow/REVIEW_AND_CLASSIFY.es.md` — translation + back-link; forward-link on EN.
-- [ ] `docs/workflow/RECOMMENDED_SKILLS.es.md` — translation + back-link; forward-link on EN.
-- [ ] `docs/workflow/ORCHESTRATION.es.md` — translation + back-link; forward-link on EN.
-- [ ] Gate: every relative link in the 4 new `.es.md` resolves; no leak.
+- [x] `docs/workflow/SKILLS.es.md` — translation + back-link; forward-link on EN.
+- [x] `docs/workflow/REVIEW_AND_CLASSIFY.es.md` — translation + back-link; forward-link on EN.
+- [x] `docs/workflow/RECOMMENDED_SKILLS.es.md` — translation + back-link; forward-link on EN.
+- [x] `docs/workflow/ORCHESTRATION.es.md` — translation + back-link; forward-link on EN.
+- [x] Gate: every relative link in the 4 new `.es.md` resolves; no leak.
+      (Verified with a link-resolution script; the two flagged items were
+      false positives — a same-page anchor and a directory reference, both
+      confirmed to exist. `npx skills add . --list` still enumerates all
+      skills. No stack/real-project reference — grep-checked, one
+      false-positive substring match on "Guardrails".)
 
 ### P3 — Replication, testing, portability, migration → ES
 

--- a/docs/fix/37-bilingual-human-docs/SPEC.md
+++ b/docs/fix/37-bilingual-human-docs/SPEC.md
@@ -314,15 +314,21 @@ literal `Hardening & PR` close-out.
 
 ### P1 — Tutorial-flow docs → ES
 
-- [ ] `docs/workflow/README.es.md` — faithful translation; back-link;
+- [x] `docs/workflow/README.es.md` — faithful translation; back-link;
       internal Pages-table links repointed to `.es.md` siblings; add
       forward-link to `docs/workflow/README.md`.
-- [ ] `docs/workflow/FEATURE_WORKFLOW.es.md` — translation + back-link;
+- [x] `docs/workflow/FEATURE_WORKFLOW.es.md` — translation + back-link;
       add forward-link to `FEATURE_WORKFLOW.md`.
-- [ ] `docs/workflow/ISSUE_WORKFLOW.es.md` — translation + back-link;
+- [x] `docs/workflow/ISSUE_WORKFLOW.es.md` — translation + back-link;
       add forward-link to `ISSUE_WORKFLOW.md`.
-- [ ] Gate: every relative link in the 3 new `.es.md` resolves; no
-      stack/real-project reference introduced.
+- [x] Gate: every relative link in the 3 new `.es.md` resolves; no
+      stack/real-project reference introduced. (Links within P1's own
+      files resolve now. `README.es.md`'s Pages-table links to
+      `SKILLS.es.md`, `REVIEW_AND_CLASSIFY.es.md`, `RECOMMENDED_SKILLS.es.md`,
+      `REPLICATE.es.md`, `MIGRATION.es.md`, `GOLDEN_FIXTURE.es.md` are
+      intentional forward references per the link-convention decision —
+      those siblings land in P2/P3 and the full link-resolution check reruns
+      at P7 Hardening. No stack/real-project reference found — grep-checked.)
 
 ### P2 — Skill & review reference → ES
 

--- a/docs/fix/37-bilingual-human-docs/SPEC.md
+++ b/docs/fix/37-bilingual-human-docs/SPEC.md
@@ -437,7 +437,7 @@ literal `Hardening & PR` close-out.
       verified with `gh pr view 50 --json body`, backticks render
       correctly, no literal `\`` escapes.)
 - [x] Update the fix-index row to `done · [#<pr>](<pr-url>)`
-- [ ] Commit `docs: link PR #37` and push
+- [x] Commit `docs: link PR #37` and push (sha `6183dd9`)
 
 ## Testing
 

--- a/docs/fix/37-bilingual-human-docs/SPEC.md
+++ b/docs/fix/37-bilingual-human-docs/SPEC.md
@@ -1,0 +1,341 @@
+# fix/37-bilingual-human-docs
+
+> Fix specification. Source of truth for this fix; its `## Phases` section
+> is the execution ledger run by `execute-phase --fix` (one phase per
+> invocation).
+
+## Goal
+
+Extend the repo's bilingual "front door" (today only `README` and
+`CHANGELOG` have EN/ES siblings) to **every human-readable documentation
+file**: the full `docs/workflow/*.md` tutorial + reference set and the
+`packages/agentic-workflow-schema/README.md` API reference. A
+Spanish-speaking reader learning the workflow — or authoring a driver
+against the schema — currently has no `.es.md` counterpart for any of it.
+This is an inconsistency in how far the bilingual pattern was applied, not
+a breach of the "committed artifacts are English" rule: that rule governs
+process artifacts (`SKILL.md`, SPECs, commits, PRs) that are
+language-neutral across any project this pack installs into — not human
+tutorial/reference prose explaining the repo to a reader. The fix also
+records a lightweight go-forward convention so the pattern stays coherent.
+
+## Issue
+
+`#37` — GitHub issue. The PR must close it via `Closes #37` in the body.
+
+## Branch
+
+`fix/37-bilingual-human-docs`
+
+## Depends on
+
+None open. Prerequisite already satisfied: `#44` (schema README full
+field/state reference) is **closed** (2026-07-11) — the schema
+`README.md` now carries the reference the owner's comment required to land
+before translating it.
+
+## Root cause
+
+Not a defect in code — a **partial application** of a convention. When the
+bilingual pattern was introduced, `README.md`/`README.es.md` and
+`CHANGELOG.md`/`CHANGELOG.es.md` (the repo's "front door") got Spanish
+siblings, but the deeper human-facing docs under `docs/workflow/` — the
+tutorial a Spanish speaker actually needs — and the schema package's
+driver-facing `README.md` never received the same treatment. There was no
+recorded scope decision either way, so the gap persisted silently.
+
+## Detected in
+
+User conversation, 2026-07-11 — noticed while asking about
+`docs/workflow/GOLDEN_FIXTURE.md`. Owner comment (2026-07-11) added
+`packages/agentic-workflow-schema/README.md` to scope, to translate after
+`#44` landed there.
+
+## Scope
+
+### In scope
+
+Create a faithful Spanish `.es.md` sibling for every human-readable doc
+below, add the reciprocal language-switcher link to each existing English
+doc, and record the go-forward convention.
+
+**`docs/workflow/` (11 files → 11 new `.es.md`):**
+
+- `README.md` (index) · `FEATURE_WORKFLOW.md` · `ISSUE_WORKFLOW.md`
+- `SKILLS.md` · `REVIEW_AND_CLASSIFY.md` · `RECOMMENDED_SKILLS.md` · `ORCHESTRATION.md`
+- `REPLICATE.md` · `GOLDEN_FIXTURE.md` · `PORTABLE_PROMPT.md` · `MIGRATION.md`
+
+**Schema package (1 file → 1 new `.es.md`):**
+
+- `packages/agentic-workflow-schema/README.md` → `README.es.md`, and add
+  `README.es.md` to the package's `files` array so it ships on npm.
+
+**Per-file mechanics (uniform, no judgement):**
+
+- The `.es.md` is a faithful, complete translation — same headings,
+  tables, code blocks, and anchors; code, commands, identifiers, file
+  paths, and skill names stay verbatim (untranslated).
+- The `.es.md` gets a back-link under its H1: `> 🇬🇧 [English version](<name>.md)`.
+- The English original gets a forward-link under its H1:
+  `> 🇪🇸 [Versión en español](<name>.es.md)`.
+- Internal relative links inside an `.es.md` point to the **`.es.md`
+  sibling when it exists in this scope**; links to files not translated
+  here (e.g. `model-routing.yml`, `SKILL.md` paths, `docs/features/`,
+  `docs/fix/`) keep their existing English target.
+
+**Convention (P5):** record in `CLAUDE.md` that human-readable docs carry
+EN + ES siblings, kept in sync **on next touch** (no automated
+bookkeeping), while `SKILL.md`, SPECs, commits, PRs, and machine config
+stay English-only.
+
+### Out of scope
+
+- `docs/workflow/model-routing.yml` — machine config, not human prose.
+  Stays English-only. (Belongs to no other fix; simply excluded.)
+- `skills/*/SKILL.md` — agent-facing contract, English-only by the CLAUDE.md
+  rule. Explicitly excluded per the issue.
+- `docs/features/**`, `docs/fix/**`, `.github/**` templates — process
+  artifacts, not human tutorial prose. Out of scope; revisit only if a
+  future issue requests it.
+- **bump-skill-style enforcement tooling** for the new ES docs — the owner
+  chose the lightweight "on next touch" convention. Automated staleness
+  checking, if ever wanted, is a separate `plan-feature` item, not this fix.
+
+## Acceptance
+
+Each criterion is an independently-verifiable checkbox. Test layer noted
+in brackets (this repo has no application build — see CLAUDE.md
+"Verification"; "docs gate" = link resolution + `npx skills add . --list`
++ no stack/real-project leak).
+
+- [ ] Every in-scope English doc has a sibling `.es.md` in the same
+      directory (12 new files total). [file-existence]
+- [ ] Every new `.es.md` opens (under its H1) with
+      `> 🇬🇧 [English version](<name>.md)` and its English original opens
+      with `> 🇪🇸 [Versión en español](<name>.es.md)`. [grep]
+- [ ] Every relative link in every new `.es.md` resolves to a file that
+      exists (ES sibling where in scope, else the EN target). [docs gate — link check]
+- [ ] Each `.es.md` preserves the source's heading structure, tables, and
+      fenced code blocks; all code/commands/identifiers/paths/skill-names
+      are byte-identical to the English source. [manual review — translation fidelity]
+- [ ] No stack/framework/real-project reference introduced by any
+      translation (generic phrasing preserved). [docs gate — leak check]
+- [ ] `packages/agentic-workflow-schema/package.json` `files` includes
+      `README.es.md`, and `npm test` in that package passes. [package test]
+- [ ] `CLAUDE.md` documents the EN+ES human-doc convention and its "on next
+      touch" (no-tooling) sync policy. [file-content]
+- [ ] `docs/fix/README.md` row for this fix reaches `done`. [file-content]
+
+**Manual verification required (why):** translation fidelity and Spanish
+fluency cannot be asserted by an automated gate — a fluent reviewer must
+spot-check that each `.es.md` says what the English says (no dropped
+sections, no invented content, no mistranslated technical claims).
+
+## Impact
+
+- **Layers touched:** documentation only (`docs/workflow/`,
+  `packages/agentic-workflow-schema/`) + repo guidance (`CLAUDE.md`) + one
+  package-manifest field (`package.json` `files`). No skills, no schema,
+  no runtime code.
+- **Modules/files:** 12 new `.es.md`; 12 English docs edited (forward-link
+  only); `packages/agentic-workflow-schema/package.json`; `CLAUDE.md`;
+  `docs/fix/README.md`.
+- **Blast radius:** dev-/reader-facing only. Worst realistic failure is a
+  broken relative link or a mistranslation — no data, no behavior, no
+  security surface. A wrong `files` entry could omit `README.es.md` from
+  the published package (caught by the acceptance check + `npm pack`).
+- **Detection lead time:** immediate at review (link check + manual
+  read); a stale/omitted translation surfaces only when a Spanish reader
+  hits it — hence the recorded on-next-touch convention.
+
+## Rules that must never be violated
+
+- **English-only process artifacts hold.** `SKILL.md`, SPECs, commits, PR
+  descriptions, and machine config remain English (CLAUDE.md "Working
+  rules"). This fix translates *human docs*, never those.
+- **Stack/architecture-agnostic.** No product/stack/framework/ORM/runtime/
+  architecture reference may be introduced into the translated docs
+  (CLAUDE.md "Working rules").
+- **Schema mirror rule.** If `packages/agentic-workflow-schema/` is
+  touched, `npm test` passes there; **any envelope-schema change** must be
+  mirrored in types + `envelope.schema.json` + version bump, same PR. This
+  fix touches only `README.es.md` + the `files` array — **no** schema
+  change — so no mirror/bump is triggered, but `npm test` must still pass.
+- **Phases labelled `P1, P2, …`**, never `S1`/"Step N" (CLAUDE.md).
+
+## Operational risks
+
+- **npm publish:** adding `README.es.md` to the `files` array means it
+  ships on the next release. Republish is issue `#38` (PR
+  [#48](https://github.com/gtrabanco/agentic-workflow/pull/48), status
+  `done`); the Spanish schema README rides that publish naturally — no
+  action needed here beyond the `files` entry. `prepublishOnly: npm test`
+  still gates it.
+- **Link rot going forward:** future renames of an English doc will orphan
+  its `.es.md` link. Mitigated only by the recorded on-next-touch
+  convention (deliberately no tooling — owner's choice).
+- **No scheduled-job / queue / cache / external-adapter interaction.**
+
+## Security risks
+
+n/a — no auth, secrets, PII, webhooks, or rate-limits touched. Translated
+prose introduces no executable content.
+
+## Compliance touchpoints
+
+n/a — no data-retention, regional, or consumer-protection rules apply to
+in-repo documentation translation.
+
+## Affected docs
+
+Each is a first-class deliverable of this fix (already covered by
+Acceptance), not a side update:
+
+- All 11 `docs/workflow/*.md` (new `.es.md` + forward-link on the EN doc).
+- `packages/agentic-workflow-schema/README.md` (new `.es.md` + `files`).
+- `CLAUDE.md` — new bilingual human-doc convention (section under "Working
+  rules").
+
+## Observability
+
+No production telemetry — docs. "Live and healthy" = the 12 `.es.md`
+files exist, every relative link resolves (`docs gate`), and
+`README.es.md` is present in `npm pack --dry-run` output for the schema
+package. Degradation (a future EN edit not mirrored to ES) is silent by
+design; the on-next-touch convention in `CLAUDE.md` is the only guard.
+
+## Cross-issue notes
+
+- **`#44`** (schema README reference) — **CLOSED**. Prerequisite for
+  translating the schema README; satisfied. No action.
+- **`#38`** (republish schema package, PR
+  [#48](https://github.com/gtrabanco/agentic-workflow/pull/48), `done`) —
+  parallel. The new `README.es.md` ships on that publish once added to
+  `files`; does not block this fix and this fix does not block it.
+- No open issue overlaps, absorbs, or is absorbed by this fix (`#37` is
+  the only other open issue — this one).
+
+## Effort
+
+**L** (multi-commit, > 1 day-equivalent) — ~90 KB of prose across 12 files
+plus 12 forward-link edits, a manifest change, and a convention note.
+
+The `plan-fix` guidance says an L item may be escalated to a feature via
+`plan-feature` — **the user decides at review**. Recommendation: keep it as
+this phased fix. The work is mechanical translation with **zero open design
+decisions**, cleanly partitioned by document cluster; the `## Phases`
+ledger already sequences it into checkable multi-commit units, which is
+exactly what `execute-phase --fix` runs. A feature SPEC would add planning
+overhead without adding design content.
+
+## Phases
+
+Execution ledger — `execute-phase --fix` runs **one phase per invocation**.
+Every translation task is independently checkable; the final phase is the
+literal `Hardening & PR` close-out.
+
+### P1 — Tutorial-flow docs → ES
+
+- [ ] `docs/workflow/README.es.md` — faithful translation; back-link;
+      internal Pages-table links repointed to `.es.md` siblings; add
+      forward-link to `docs/workflow/README.md`.
+- [ ] `docs/workflow/FEATURE_WORKFLOW.es.md` — translation + back-link;
+      add forward-link to `FEATURE_WORKFLOW.md`.
+- [ ] `docs/workflow/ISSUE_WORKFLOW.es.md` — translation + back-link;
+      add forward-link to `ISSUE_WORKFLOW.md`.
+- [ ] Gate: every relative link in the 3 new `.es.md` resolves; no
+      stack/real-project reference introduced.
+
+### P2 — Skill & review reference → ES
+
+- [ ] `docs/workflow/SKILLS.es.md` — translation + back-link; forward-link on EN.
+- [ ] `docs/workflow/REVIEW_AND_CLASSIFY.es.md` — translation + back-link; forward-link on EN.
+- [ ] `docs/workflow/RECOMMENDED_SKILLS.es.md` — translation + back-link; forward-link on EN.
+- [ ] `docs/workflow/ORCHESTRATION.es.md` — translation + back-link; forward-link on EN.
+- [ ] Gate: every relative link in the 4 new `.es.md` resolves; no leak.
+
+### P3 — Replication, testing, portability, migration → ES
+
+- [ ] `docs/workflow/REPLICATE.es.md` — translation + back-link; forward-link on EN.
+- [ ] `docs/workflow/GOLDEN_FIXTURE.es.md` — translation + back-link; forward-link on EN.
+- [ ] `docs/workflow/PORTABLE_PROMPT.es.md` — translation + back-link; forward-link on EN.
+- [ ] `docs/workflow/MIGRATION.es.md` — translation + back-link; forward-link on EN.
+- [ ] Gate: every relative link in the 4 new `.es.md` resolves; no leak.
+
+### P4 — Schema package API reference → ES
+
+- [ ] `packages/agentic-workflow-schema/README.es.md` — faithful
+      translation + back-link; add forward-link to the package `README.md`.
+- [ ] Add `"README.es.md"` to the `files` array in
+      `packages/agentic-workflow-schema/package.json`.
+- [ ] Gate: `npm test` in the package passes; `npm pack --dry-run` lists
+      `README.es.md`; relative links resolve.
+
+### P5 — Sync-policy convention
+
+- [ ] `CLAUDE.md`: under "Working rules", record that **human-readable
+      docs** (`README`, `CHANGELOG`, `docs/workflow/*.md`, the schema
+      package `README`) carry EN + ES siblings kept in sync **on next
+      touch** — no automated bookkeeping — while `SKILL.md`, SPECs,
+      commits, PRs, and machine config (`model-routing.yml`) stay
+      English-only.
+- [ ] Gate: `CLAUDE.md` still links resolve; wording is generic (no
+      stack/project reference).
+
+### P6 — Hardening & PR
+
+- [ ] Re-run the project's full verification gate (commands + exit codes pasted)
+- [ ] Pending-docs check: `git status --porcelain -- docs/` → empty
+- [ ] Set the fix-index row status to `done` and commit the flip
+- [ ] `git push`
+- [ ] Open the PR (`gh pr create --body-file <path>` — body written as a
+      Markdown file, real backticks, never inline `--body`/heredoc) and
+      PRINT THE PR URL in the chat; the body includes `Closes #37`
+- [ ] Update the fix-index row to `done · [#<pr>](<pr-url>)`
+- [ ] Commit `docs: link PR #37` and push
+
+## Testing
+
+No unit/integration layer applies (documentation). Verification is:
+
+1. **Docs gate** — link resolution across every new `.es.md`, `npx skills
+   add . --list` still enumerates all skills, no stack/real-project leak.
+2. **Package test** — `npm test` in `packages/agentic-workflow-schema`
+   (P4), plus `npm pack --dry-run` to confirm `README.es.md` is packaged.
+3. **Manual review** — a fluent reader spot-checks translation fidelity
+   (mandatory; not automatable).
+
+Existing tests at regression risk: none — no code path changes; the schema
+package test only re-runs to confirm the manifest edit is inert.
+
+## Rollback
+
+`git revert` the merge commit (or PR-revert flow): deletes the 12
+`.es.md`, restores the English docs' pre-link state, reverts the
+`package.json` `files` entry and the `CLAUDE.md` convention. No data-side
+cleanup — no schema, migration, or state change. Nothing is lost beyond the
+translations themselves (recoverable from git history).
+
+## Status
+
+`pending`
+
+## Decisions made during drafting
+
+- **Scope = all human-readable docs**, per the user's answer ("tutorial and
+  api reference docs … documents to be read by human"): the full
+  `docs/workflow/*.md` set (not just the reader-facing subset) **plus** the
+  schema package `README`. `model-routing.yml` excluded as machine config.
+- **Sync policy = lightweight convention, no tooling**, per the user's
+  answer — documented in `CLAUDE.md`, enforced "on next touch". No
+  bump-skill extension (that would be a separate `plan-feature` item).
+- **Link convention inside `.es.md`:** point to the `.es.md` sibling when
+  it exists in this scope, otherwise keep the English target. Chosen so a
+  Spanish reader stays in Spanish where a translation exists without
+  producing dangling links to untranslated files.
+- **Forward-link added to each English doc** (`> 🇪🇸 …`) mirroring the
+  existing root-`README.md` pattern — the `docs/workflow/*.md` files have
+  none today, so establishing the pair edits both sides.
+- **Phase grouping by document cluster** (flow / reference / replication /
+  schema / policy) rather than one phase per file — keeps each phase a
+  single coherent concern while staying independently checkable.

--- a/docs/fix/37-bilingual-human-docs/SPEC.md
+++ b/docs/fix/37-bilingual-human-docs/SPEC.md
@@ -383,7 +383,7 @@ literal `Hardening & PR` close-out.
 
 ### P5 — Model-routing recommendation revision
 
-- [ ] `README.md`: rewrite the "Running on NaN.builders" section + the
+- [x] `README.md`: rewrite the "Running on NaN.builders" section + the
       "If GLM-5.2 is down" fallback ladder into the two-profile,
       quota-aware shape specified in Scope → Model-routing revision:
       GLM-5.2 = €200-plan option (not the basic-plan primary); quota-aware
@@ -394,12 +394,16 @@ literal `Hardening & PR` close-out.
       Qwen3.6 for merge gates / defer to human" rule; the 5-model pros/cons
       table. No unverified benchmark numbers; keep the "sanity-check
       against a current leaderboard" caveat.
-- [ ] `README.es.md`: mirror the **same** revised section as a faithful
+- [x] `README.es.md`: mirror the **same** revised section as a faithful
       Spanish translation — identical ladders, config values, model names,
       and table rows; no divergence from `README.md`.
-- [ ] Gate: EN and ES model tables/ladders match 1:1 (diff the two
+- [x] Gate: EN and ES model tables/ladders match 1:1 (diff the two
       sections); all links in both still resolve; no invented benchmark
-      claim introduced.
+      claim introduced. (Verified: model names, sizes, context, quota
+      figures, and ladder ordering are identical across both files —
+      grep-counted, with the only surface differences being the localized
+      unit labels "tok/member/mo" vs. "tok/miembro/mes". `npx skills add .
+      --list` green; no stack/real-project leak.)
 
 ### P6 — Sync-policy convention
 

--- a/docs/fix/37-bilingual-human-docs/SPEC.md
+++ b/docs/fix/37-bilingual-human-docs/SPEC.md
@@ -357,11 +357,18 @@ literal `Hardening & PR` close-out.
 
 ### P3 — Replication, testing, portability, migration → ES
 
-- [ ] `docs/workflow/REPLICATE.es.md` — translation + back-link; forward-link on EN.
-- [ ] `docs/workflow/GOLDEN_FIXTURE.es.md` — translation + back-link; forward-link on EN.
-- [ ] `docs/workflow/PORTABLE_PROMPT.es.md` — translation + back-link; forward-link on EN.
-- [ ] `docs/workflow/MIGRATION.es.md` — translation + back-link; forward-link on EN.
-- [ ] Gate: every relative link in the 4 new `.es.md` resolves; no leak.
+- [x] `docs/workflow/REPLICATE.es.md` — translation + back-link; forward-link on EN.
+- [x] `docs/workflow/GOLDEN_FIXTURE.es.md` — translation + back-link; forward-link on EN.
+- [x] `docs/workflow/PORTABLE_PROMPT.es.md` — translation + back-link; forward-link on EN
+      (the pasteable prompt fence itself kept verbatim/untranslated per the
+      code-block rule — translating a literal paste-in prompt would change
+      what the agent executes; noted inline in the ES doc).
+- [x] `docs/workflow/MIGRATION.es.md` — translation + back-link; forward-link on EN
+      (two same-page anchor links re-slugged to match the translated
+      headings; verified programmatically against GitHub's slug algorithm).
+- [x] Gate: every relative link in the 4 new `.es.md` resolves; no leak.
+      (`npx skills add . --list` green; grep-checked for stack/real-project
+      leaks — none found.)
 
 ### P4 — Schema package API reference → ES
 

--- a/docs/fix/37-bilingual-human-docs/SPEC.md
+++ b/docs/fix/37-bilingual-human-docs/SPEC.md
@@ -407,14 +407,17 @@ literal `Hardening & PR` close-out.
 
 ### P6 — Sync-policy convention
 
-- [ ] `CLAUDE.md`: under "Working rules", record that **human-readable
+- [x] `CLAUDE.md`: under "Working rules", record that **human-readable
       docs** (`README`, `CHANGELOG`, `docs/workflow/*.md`, the schema
       package `README`) carry EN + ES siblings kept in sync **on next
       touch** — no automated bookkeeping — while `SKILL.md`, SPECs,
       commits, PRs, and machine config (`model-routing.yml`) stay
       English-only.
-- [ ] Gate: `CLAUDE.md` still links resolve; wording is generic (no
-      stack/project reference).
+- [x] Gate: `CLAUDE.md` still links resolve; wording is generic (no
+      stack/project reference). (Only "broken" matches from the link
+      checker were the literal `<name>.es.md`/`<name>.md` placeholder
+      pattern inside the new bullet's own prose, not real links. No
+      stack/real-project leak; `npx skills add . --list` still green.)
 
 ### P7 — Hardening & PR
 

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -15,7 +15,7 @@ this table — history lives in git log + closed issues.
 | Folder | Topic | Status | Depends on | Issue |
 | ------ | ----- | ------ | ---------- | ----- |
 | `38-schema-package-republish` | Republish schema package (bump 1.0.1 → 1.0.2 so the stranded #44 README reaches npm) | done · [#48](https://github.com/gtrabanco/agentic-workflow/pull/48) | — | [#38](https://github.com/gtrabanco/agentic-workflow/issues/38) |
-| `37-bilingual-human-docs` | Spanish `.es.md` siblings for all human-readable docs (`docs/workflow/*.md` + schema package README) + on-next-touch sync convention; also folds in the model-routing recommendation revision (GLM-5.2 → €200 plan, quota-aware per-task ladders) | done | — | [#37](https://github.com/gtrabanco/agentic-workflow/issues/37) |
+| `37-bilingual-human-docs` | Spanish `.es.md` siblings for all human-readable docs (`docs/workflow/*.md` + schema package README) + on-next-touch sync convention; also folds in the model-routing recommendation revision (GLM-5.2 → €200 plan, quota-aware per-task ladders) | done · [#50](https://github.com/gtrabanco/agentic-workflow/pull/50) | — | [#37](https://github.com/gtrabanco/agentic-workflow/issues/37) |
 
 ---
 

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -15,7 +15,7 @@ this table — history lives in git log + closed issues.
 | Folder | Topic | Status | Depends on | Issue |
 | ------ | ----- | ------ | ---------- | ----- |
 | `38-schema-package-republish` | Republish schema package (bump 1.0.1 → 1.0.2 so the stranded #44 README reaches npm) | done · [#48](https://github.com/gtrabanco/agentic-workflow/pull/48) | — | [#38](https://github.com/gtrabanco/agentic-workflow/issues/38) |
-| `37-bilingual-human-docs` | Spanish `.es.md` siblings for all human-readable docs (`docs/workflow/*.md` + schema package README) + on-next-touch sync convention; also folds in the model-routing recommendation revision (GLM-5.2 → €200 plan, quota-aware per-task ladders) | pending | — | [#37](https://github.com/gtrabanco/agentic-workflow/issues/37) |
+| `37-bilingual-human-docs` | Spanish `.es.md` siblings for all human-readable docs (`docs/workflow/*.md` + schema package README) + on-next-touch sync convention; also folds in the model-routing recommendation revision (GLM-5.2 → €200 plan, quota-aware per-task ladders) | done | — | [#37](https://github.com/gtrabanco/agentic-workflow/issues/37) |
 
 ---
 

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -15,7 +15,7 @@ this table — history lives in git log + closed issues.
 | Folder | Topic | Status | Depends on | Issue |
 | ------ | ----- | ------ | ---------- | ----- |
 | `38-schema-package-republish` | Republish schema package (bump 1.0.1 → 1.0.2 so the stranded #44 README reaches npm) | done · [#48](https://github.com/gtrabanco/agentic-workflow/pull/48) | — | [#38](https://github.com/gtrabanco/agentic-workflow/issues/38) |
-| `37-bilingual-human-docs` | Spanish `.es.md` siblings for all human-readable docs (`docs/workflow/*.md` + schema package README) + on-next-touch sync convention | pending | — | [#37](https://github.com/gtrabanco/agentic-workflow/issues/37) |
+| `37-bilingual-human-docs` | Spanish `.es.md` siblings for all human-readable docs (`docs/workflow/*.md` + schema package README) + on-next-touch sync convention; also folds in the model-routing recommendation revision (GLM-5.2 → €200 plan, quota-aware per-task ladders) | pending | — | [#37](https://github.com/gtrabanco/agentic-workflow/issues/37) |
 
 ---
 

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -15,6 +15,7 @@ this table — history lives in git log + closed issues.
 | Folder | Topic | Status | Depends on | Issue |
 | ------ | ----- | ------ | ---------- | ----- |
 | `38-schema-package-republish` | Republish schema package (bump 1.0.1 → 1.0.2 so the stranded #44 README reaches npm) | done · [#48](https://github.com/gtrabanco/agentic-workflow/pull/48) | — | [#38](https://github.com/gtrabanco/agentic-workflow/issues/38) |
+| `37-bilingual-human-docs` | Spanish `.es.md` siblings for all human-readable docs (`docs/workflow/*.md` + schema package README) + on-next-touch sync convention | pending | — | [#37](https://github.com/gtrabanco/agentic-workflow/issues/37) |
 
 ---
 

--- a/docs/workflow/FEATURE_WORKFLOW.es.md
+++ b/docs/workflow/FEATURE_WORKFLOW.es.md
@@ -1,0 +1,310 @@
+# Flujo de trabajo de features (de extremo a extremo)
+
+> 🇬🇧 [English version](FEATURE_WORKFLOW.md)
+
+Desde una idea o un issue de solicitud de feature hasta un PR fusionado —
+cada paso y la skill que lo impulsa. El ciclo de vida, según `CLAUDE.md`, es
+el **pipeline de cinco etapas**:
+
+```
+design (design-feature) → plan (plan-feature) → execute (execute-phase)
+  → review (review-change) → audit (audit-pr / product-audit)
+```
+
+Cada feature se transporta en **un único `SPEC.md`, escrito en dos mitades**:
+`design-feature` escribe la **mitad de producto** (objetivo, contexto,
+alcance, cierre de capacidades → criterios de aceptación, herramientas,
+decisiones de producto) y sella `## Design status`; `plan-feature` se niega a
+planificar una feature cuya mitad de producto no esté marcada como
+`designed`, y luego escribe la **mitad de ingeniería** (impacto en la
+arquitectura, diseño, fases, testing, escenarios de desarrollo, despliegue y
+rollback, entregables). Ver `docs/features/_TEMPLATE/SPEC.md` para el
+esquema exacto de secciones.
+
+## Etapa 0 — Diseño (`design-feature`)
+
+**Definición de producto y cierre de capacidades** — la etapa que convierte
+una idea o una solicitud de feature en un conjunto exhaustivo y verificable
+de criterios de aceptación, para que los modelos ejecutores no punteros no
+omitan silenciosamente el trabajo implícito (p. ej. "auth con gestión de
+dashboard y ACLs" no debe colapsar en una tabla de usuarios + una vista de
+listado).
+
+`design-feature <slug>`:
+
+- Incorpora la entrevista de idea-en-bruto (problema y objetivo, alcance
+  dentro/fuera, pistas de arquitectura, preocupaciones transversales) cuando
+  se parte de cero.
+- Ejecuta **investigación proporcional**: primero la checklist de cierre de
+  capacidades (barata), investigación externa/de dominio solo cuando el
+  dominio es nuevo para el proyecto — sin investigación de mercado
+  sistemática por feature.
+- Recorre la **checklist de cierre de capacidades**: para cada entidad
+  introducida o tocada, CRUD + transiciones de estado, cada una con un punto
+  de entrada de UI + superficie de API + test, o un `n/a: <razón>` explícito;
+  para cada capacidad, su punto de entrada y quién puede ejecutarla; para
+  cada rol/permiso, dónde se asigna, se revoca y se visualiza. Una fila en
+  blanco hace fallar la puerta; las filas rellenadas se convierten en los
+  criterios de Aceptación.
+- Registra notas de herramientas por feature (skills/MCPs instaladas
+  relevantes para *esta* feature — un barrido global es tarea de
+  `product-audit`, no de esto).
+- **Upserts**: volver a ejecutar sobre un slug existente relee el SPEC +
+  `decisions.md` y nunca destruye decisiones registradas — las revisiones se
+  añaden a `decisions.md`.
+- **Regla de interacción**: `design-feature <slug>` a secas imprime un
+  resumen y pregunta qué añadir/quitar/cambiar (modo revisión);
+  `design-feature <slug> <instrucción>` aplica el cambio directamente, sin
+  preguntas.
+- Se reduce para features XS: la entrevista puede ser una única pregunta y la
+  mayoría de las filas de cierre se resuelven como `n/a` — la puerta se
+  mantiene uniforme, pero pasarla es barato.
+
+Una vez que cada fila de cierre está rellenada o explícitamente marcada
+`n/a`, `design-feature` fija `## Design status` en `designed` y entrega el
+control a `/plan-feature <slug>`.
+
+### La puerta de redirección
+
+`plan-feature` basa su puerta en el marcador `## Design status` del SPEC: sin
+`SPEC.md`, o el marcador ausente/distinto de `designed`, o la sección de
+cierre de capacidades vacía → **STOP**, sin flag de bypass:
+
+```
+→ Next: /design-feature <slug> — this feature has no completed product design yet
+  (capability closure not done). Design it first; then re-run /plan-feature <slug>.
+```
+
+Marcador `designed` y cierre presente → `plan-feature` procede a construir el
+andamiaje de la mitad de ingeniería.
+
+## Etapa 1 — Planificar: qué camino, luego SPEC + artefactos
+
+**Un único punto de entrada** — `plan-feature` — detecta de dónde viene el
+trabajo y enruta al paso interno correcto:
+
+| Tienes… | Invoca | El router ejecuta | Resultado |
+|---|---|---|---|
+| Una feature sin diseñar (sin `SPEC.md`, o `## Design status` distinto de `designed`) | `plan-feature <slug>` | — | **STOP**, redirige a `/design-feature <slug>` (ver arriba) |
+| Un issue de GitHub que solicita una feature | `plan-feature <N>` (o `--from-issue N`) | `plan-feature-from-issue` | Issue → mitad de producto del SPEC rellenada (satisface el cierre), con `Closes #N` |
+| Una feature/SPEC ya diseñada (`## Design status: designed`) | `plan-feature <slug>` (o `--scaffold`) | `plan-feature-scaffold` | Mitad de ingeniería rellenada + andamiaje de artefactos |
+| Nada — tomar el siguiente ítem del roadmap | `plan-feature --next` | toma la siguiente entrada `planned` | La construye (redirige primero a `design-feature` si no está diseñada) |
+
+Todos los caminos **leen primero el proyecto** (guía del agente, mapa de
+documentación, arquitectura, roadmap, docs de dominio/estilo) para que la
+feature respete las restricciones reales del código base. Solo llamas a
+`plan-feature`; los pasos internos de abajo se invocan por ti (nunca
+aparecen en el menú). La entrevista de idea-en-bruto que antes ejecutaba
+`plan-feature` ahora vive en `design-feature` (Etapa 0) — `plan-feature` es
+solo planificación de ingeniería.
+
+### El camino del issue — `plan-feature-from-issue`
+
+Lee el issue, **confirma que realmente es una feature** (un bug/deuda
+técnica se enruta a `triage-issue`), traduce al idioma de los docs si hace
+falta, lo mapea al roadmap (número, slug, dependencias, conflictos), cierra
+contigo los huecos de alcance, escribe la mitad de producto del SPEC
+(satisfaciendo el cierre de capacidades — entregando issues escuetos a
+`design-feature` cuando hace falta), y conecta `Closes #N` para el PR
+eventual.
+
+## Etapa 1b — Planificar: SPEC + artefactos (`plan-feature-scaffold`)
+
+Una vez que la feature está diseñada (`## Design status: designed`), el
+router ejecuta `plan-feature-scaffold`, que rellena la **mitad de
+ingeniería** y escribe **solo docs** en `docs/features/<NN>-<slug>/`. **El
+conjunto de artefactos escala según el `Size` del SPEC:**
+
+- **XS/S** (≤ un commit / ≤ medio día) — `SPEC.md` es el **único** artefacto
+  de planificación; sin ceremonia PLAN/TASKS, pero su sección `### Phases`
+  lista **≥ 2 fases** (`P1` implementación, `P2 — Hardening & PR` = el
+  cierre). Siguiente paso: `execute-phase <NN>` (ejecuta `P1`; una fase por
+  invocación).
+- **M/L** (trabajo por fases) — el conjunto completo:
+  - `SPEC.md` — cada sección rellenada (objetivos, impacto en arquitectura,
+    aceptación, rama, tamaño, dependencias, testing, escenarios de
+    desarrollo).
+  - `PLAN.md` — plan por fases cuya **última fase de implementación es
+    siempre una fase de hardening** (casos límite + los modos de fallo de los
+    escenarios de desarrollo del SPEC, implementados y probados — no solo
+    documentados).
+  - `TASKS.md`, `progress.md`, `testing.md`, `known-issues.md`,
+    `decisions.md`, `architecture-notes.md` — reflejando el conjunto que usan
+    las features recientes.
+  - **L** también sugiere: considerar dividir en features independientemente
+    entregables.
+
+Luego **registra la feature en el roadmap** (numeración, orden,
+dependencias). No crea la rama ni escribe código.
+
+> Las incógnitas se convierten en preguntas abiertas en `decisions.md` —
+> nunca en placeholders en blanco.
+
+## Etapa 2 — Ejecutar, una fase a la vez (`execute-phase`)
+
+`execute-phase` (modo por defecto) implementa **una fase** por ejecución:
+
+1. Verifica la rama — crea `feat/<NN>-<slug>` si estás en `main` (nunca
+   trabaja sobre `main`). **En P1 primero confirma los artefactos de
+   planificación por separado** (`docs(NN-slug): planning artifacts`), de
+   modo que el historial de planificación quede aparte de la implementación.
+2. Lee `progress.md` (qué hicieron las fases anteriores), luego `SPEC.md` +
+   `TASKS.md` de la fase solicitada.
+3. Implementa **solo esa fase** — **tests primero** en el trabajo de
+   core/dominio y orquestación: los tests de aceptación/integración de la
+   fase se escriben en rojo, y luego se implementa hasta verde (los
+   escenarios de desarrollo del SPEC son la lista de tests). Sin agrupar
+   fases, sin abstracción prematura, sin refactors no relacionados.
+4. Ejecuta la puerta de verificación del proyecto (chequeo de tipos, tests,
+   build). **Nunca confirma en rojo** — un fallo que no se puede arreglar
+   dentro del alcance va a `known-issues.md` y la ejecución se detiene con un
+   informe.
+5. Actualiza `TASKS.md`, `progress.md`, `testing.md`, `known-issues.md` (y
+   `decisions.md` si la arquitectura se movió). Cuando la realidad
+   contradice el plan, se actualizan `TASKS.md`/`PLAN.md` y el porqué se
+   registra en `decisions.md` — nunca una divergencia silenciosa.
+6. Confirma (commit) en formato convencional — un commit por fase.
+7. Se detiene para revisión (fases intermedias). **La fase final** (para
+   XS/S, su `P2 — Hardening & PR`) en cambio **cambia la fila del roadmap a
+   `done` y abre el PR** (nunca solo-rama) — ver Etapa 5 — luego el
+   obligatorio `/review-change` → `/audit-pr`.
+
+**Una fase = una sesión.** Nunca ejecutar dos fases en una sola conversación
+con un modelo no puntero — los modelos se degradan en horizontes largos, y
+una sesión nueva por fase es lo que preserva la garantía de ejecución barata
+(la economía "el SPEC caro y cerrado compra ejecución barata ilimitada"). La
+forma de lote de `/loop` ya limpia y reinvoca por fase; en un agente sin
+`/loop`, reinvoca `execute-phase` a mano para cada fase en una conversación
+nueva.
+
+Repetir para cada fase (P1, P2, …). Las features pequeñas (`Size: XS/S`) se
+manejan con `execute-phase <NN>` en un solo pase — sin skill separada; el
+pase único termina cambiando la fila del roadmap a `done` y abriendo el PR,
+luego el obligatorio `/review-change` → `/audit-pr`. Para ejecutar todas las
+fases sin supervisión (los checkpoints cada 2 fases se saltan, pero la
+revisión final **obligatoria** no — sigue corriendo una vez antes del PR),
+ver el patrón de **ejecución por lotes con `/loop`** en la skill
+`execute-phase`.
+
+> ¿Quieres construir **todo el roadmap** así — cada feature a través de cada
+> etapa, con tu única intervención en los merges? Ese es el autopiloto
+> `ship-roadmap`: una entrevista inicial, y luego una ejecución impulsada por
+> `/loop` de este mismo flujo, feature por feature, terminando en un informe
+> final. Ver su entrada en [SKILLS.es.md](SKILLS.es.md).
+
+Durante la ejecución, las skills de conocimiento de dominio se cargan
+automáticamente como guardarraíles: las skills de guardarraíl de
+stack/dominio del proyecto (patrón de arquitectura, reglas de dominio,
+framework, ORM, runtime/plataforma).
+
+## Higiene de contexto y coste
+
+La forma barata de correr este flujo es también la forma documentada. Reglas
+fijas:
+
+- **Fin de una unidad o fase → `/log-session`, luego una conversación
+  NUEVA.** Nunca compactar para cruzar esa frontera. Los docs
+  SPEC/TASKS/progress más el log de sesión YA SON la memoria persistente —
+  una conversación nueva recarga solo esos, no toda la transcripción previa.
+- **Las entregas a review/audit → siempre una conversación nueva.** Ya es el
+  contrato (el modelo/effort de una skill solo compone dentro de su propio
+  turno); esta es la misma regla enunciada para su economía, no una nueva.
+- **Compactar solo a mitad de fase**, y solo cuando tienes estado sin
+  persistir que no puedes permitirte perder. Aun así, prefiere confirmar el
+  trabajo en curso más una nota en `progress.md` y cortar a una conversación
+  nueva antes que compactar.
+- **Por qué es caro:** la compactación relee **toda** la conversación con el
+  modelo de sesión **actualmente seleccionado** (coste de entrada) y escribe
+  el resumen (coste de salida). El auto-compact se dispara cerca del límite
+  de contexto — justo cuando releer es más caro. Una conversación nueva
+  cuesta casi cero en comparación, porque los docs propios del flujo son la
+  memoria, no la transcripción.
+
+## Etapa 3 — Hardening
+
+**Siempre la última fase de implementación en `PLAN.md`** (el andamiaje la
+coloca ahí para cada feature M/L — no es opcional). Se ejecuta como una fase
+vía `execute-phase`: casos límite, modos de fallo de los escenarios de
+desarrollo del SPEC, estados vacíos/degradados, condiciones de carrera,
+idempotencia, mapeo de errores, y reglas de divulgación (p. ej. no ocultar
+limitaciones visibles para el usuario). Sigue con docs actualizados y
+verificada por la puerta como cualquier fase.
+
+## Etapa 4 — Review & audit (rama completa)
+
+`execute-phase` **recomienda** un checkpoint de `review-change` cada 2 fases
+(una sugerencia que se puede saltar — continuar a la siguiente fase es una
+alternativa listada) **y entrega el control una vez al final (obligatorio —
+cada unidad recibe una revisión final antes de su puerta de merge)**. Una
+unidad terminada **siempre abre su PR y pasa a `done`** (construida, no
+fusionada — el estado de merge vive en la forja); la revisión final y la
+puerta de merge se ejecutan entonces sobre el PR:
+
+- **`review-change`** — el orquestador. Ejecuta solo las revisiones que
+  **aplican a esta plataforma**, comprueba **desviación del SPEC** (¿el diff
+  realmente hace lo que promete el SPEC — nada contradicho, superado
+  silenciosamente, o dejado sin tocar?), y sintetiza una **tabla de decisión
+  clasificada** más una checklist explícita de verificación manual. Compone:
+  - `review-implementation` — revisión de dos fases sobre bugs, violaciones
+    de arquitectura, código eliminable/muerto (menos el código de feature
+    planificada), seguridad, incompatibilidades de plataforma/runtime,
+    sobre-ingeniería, riesgos de bundle, y tests (fallando **y** faltantes),
+    cada uno clasificado como fix-now / postpone / ignore /
+    intentional-tradeoff con el PORQUÉ, riesgo de implementación, impacto a
+    largo plazo, y una marca de optimización prematura.
+  - `/code-review`, `/security-review`, `/verify`, y — para UI —
+    `design-review`, `accessibility-review`, `brand-review` (solo las
+    aplicables; nunca una pasada irrelevante).
+
+  Solo hallazgos, sin refactorizar; `fix-now` se enruta a `plan-fix` (o se
+  incorpora a la fase actual si es trabajo aún sin fusionar); **cada hallazgo
+  que no es fix-now pasa por `triage-issue`** (issue / decisión documentada /
+  descarte justificado), nunca se pierde en silencio.
+- **`audit-pr`** — la puerta de merge. Criterios de aceptación cumplidos,
+  todas las fases completas, docs/tests/CI en verde (**nunca fusionar con
+  docs pendientes**), `Closes #N` presente, la entrada de issue/índice de
+  fixes aún rastreada (se elimina solo después del merge), rama
+  independientemente fusionable, y los ejes de revisión limpios →
+  **merge-ready o una lista de bloqueadores**.
+
+Vuelve a ejecutar la puerta (chequeo de tipos, tests, build) en verde.
+
+## Etapa 5 — PR
+
+- **El PR siempre se abre — cada unidad, incluida una feature `XS/S` o un
+  fix, nunca termina solo-en-rama.** Abrir el PR es el último paso de la
+  unidad y cambia su estado de roadmap/índice de fixes a `done` (construida,
+  no fusionada).
+- Base **siempre** `main`; la rama debe ser **independientemente
+  fusionable**.
+- **Nunca apilar PRs.** Si una feature es demasiado grande, dividirla en
+  porciones independientemente entregables — nunca por fases internas.
+- Título convencional; el cuerpo incluye `Closes #N` si vino de un issue.
+- La checklist de pre-commit (de `CLAUDE.md`): la puerta (chequeo de tipos,
+  tests, build) en verde, sin violaciones de arquitectura, sin secretos
+  hardcodeados, sin limitaciones ocultas para el usuario, y cualquier otra
+  regla mandatada por el proyecto satisfecha.
+
+## Ejemplo trabajado
+
+```
+/design-feature  "<your feature>"   → interview + capability closure
+   → product half of SPEC filled, `## Design status: designed` (offers to open a tracking issue)
+/plan-feature  NN                   → gate reads `designed` → proceeds (no redirect)
+   → engineering half filled → scaffolds docs/features/NN-<slug>/{SPEC,PLAN,TASKS,…}.md + roadmap entry
+/execute-phase  NN  P1              → data/domain layer, gate green, commit
+/execute-phase  NN  P2              → orchestration + adapter, gate green, commit
+   → recommended review checkpoint (every 2 phases, skippable): /review-change → classified table + manual checks
+/execute-phase  NN  hardening       → edge cases, gate green, commit
+   → final phase: flip roadmap to `done`, open the PR ("Closes #<issue>")
+/review-change                      → mandatory final review; non-fix-now → triage-issue
+/audit-pr                           → merge gate: merge-ready or blockers (never merge with pending docs)
+   → human merges
+```
+
+(Para una feature `XS/S` o un `--fix`, `execute-phase` ejecuta la sección
+`## Phases` del SPEC una por invocación — la fase final `Hardening & PR`
+hace el cierre de marcar-como-done → abrir-PR. Un SPEC heredado sin
+`## Phases` ejecuta implementar → marcar-como-done → abrir-PR en un solo
+pase. De cualquier forma, sigue el mismo obligatorio `/review-change` →
+`/audit-pr`.)

--- a/docs/workflow/FEATURE_WORKFLOW.md
+++ b/docs/workflow/FEATURE_WORKFLOW.md
@@ -1,5 +1,7 @@
 # Feature workflow (end-to-end)
 
+> 🇪🇸 [Versión en español](FEATURE_WORKFLOW.es.md)
+
 From an idea or a feature-request issue to a merged PR — every step and the skill
 that drives it. The lifecycle, per `CLAUDE.md`, is the **five-stage pipeline**:
 

--- a/docs/workflow/GOLDEN_FIXTURE.es.md
+++ b/docs/workflow/GOLDEN_FIXTURE.es.md
@@ -1,0 +1,172 @@
+# Procedimiento del fixture dorado
+
+> 🇬🇧 [English version](GOLDEN_FIXTURE.md)
+
+Una prueba de humo repetible para el redactado de las skills: ejecutar una
+feature de juguete pequeña y fija a través de una skill modificada **con
+el modelo más débil de tu flota**, y comprobar que su salida contractual
+se mantiene. Esto es la U9 del backlog de 2026-07-09
+([#19](https://github.com/gtrabanco/agentic-workflow/issues/19)); cierra
+el hueco de aplicación que la feature 08 (`phase-economics`) le dejó
+diferido (`docs/features/08-phase-economics/known-issues.md`).
+
+## Propósito
+
+La sección "Checklists over heuristics" de CLAUDE.md promete que cada
+skill "must run correctly on any agent and any model". Esa promesa no
+está probada: los cuerpos de las skills se reescriben libremente, y un
+cambio de redacción que un modelo puntero absorbe sin problema puede
+romper silenciosamente a un modelo local débil (Qwen3.6 35B / Gemma4 26B)
+que ejecuta una fase — una casilla del contrato de turno omitida, un
+bloque de salida fijo renderizado de forma laxa, un paso inventado. Este
+procedimiento detecta esa regresión antes de que se publique, manualmente,
+sin infraestructura.
+
+## Cuándo ejecutarlo
+
+Tras editar cualquier skill del **camino ejecutor**: `execute-phase`,
+`plan-feature`, `plan-feature-scaffold`, `plan-feature-from-issue`,
+`design-feature`, o cualquier skill del paquete `review-*`. Opcional pero
+recomendado antes de abrir el PR de esa edición.
+
+## El fixture
+
+Una feature de juguete fija — **"añadir un comando de exportación CSV"**
+— con un SPEC de juguete preescrito y el texto de issue de una línea que
+representa.
+
+Para skills que toman una idea en bruto o un issue como entrada
+(`design-feature`, `plan-feature-from-issue`), usa esta línea única en
+lugar del SPEC de abajo:
+
+> Add an `export-csv` command to the toy CLI that writes the current
+> in-memory record list to a CSV file at a given path.
+
+Para cualquier otra skill del camino ejecutor (`execute-phase`,
+`plan-feature`, `plan-feature-scaffold`, el paquete `review-*`), usa el
+SPEC de juguete preescrito de abajo — ya está `designed`, así que esas
+skills pueden ejecutarse directamente contra él. Copia el bloque que
+necesites a una ubicación de borrador (p. ej. tu scratchpad); **no** lo
+confirmes como una carpeta de feature bajo `docs/features/`.
+
+```markdown
+# 99 — csv-export-command
+
+## Goal
+
+Add a `export-csv` command to the toy CLI that writes the current in-memory
+record list to a CSV file at a given path.
+
+## Branch
+
+`feat/99-csv-export-command`
+
+## Size
+
+`XS` — single command, no new dependencies, 2 phases.
+
+## Dependencies
+
+None.
+
+## Product half
+
+### Context
+
+Users currently can only view records on screen; they want a file they can
+open in a spreadsheet.
+
+### Scope
+
+#### In scope
+- `export-csv <path>` command: writes all records to `<path>` as CSV
+  (header row + one row per record).
+
+#### Out of scope
+- Filtering, sorting, or partial export — always exports the full record set.
+
+### Acceptance criteria
+- Running `export-csv out.csv` creates `out.csv` with a header row and one
+  data row per record.
+- Running it with no records writes a header-only file (exit 0).
+
+## Design status
+
+`designed`
+
+## Engineering half
+
+### Design
+
+One new command handler that serializes the in-memory record list to CSV and
+writes it to the given path; reuse the project's existing file-write helper
+if one exists.
+
+### Phases
+
+#### P1 — implement `export-csv`
+
+- [ ] Command handler writes a header row + one row per record to `<path>`
+- [ ] Empty record set → header-only file, exit 0
+
+#### P2 — Hardening & PR
+
+- [ ] Re-run the project's full verification gate (commands + exit codes pasted)
+- [ ] Pending-docs check: `git status --porcelain -- docs/` → empty
+- [ ] Set the roadmap row status to `done` and commit the flip
+- [ ] `git push`
+- [ ] Open the PR (`gh pr create --body-file <path>` — body written as a
+      Markdown file, real backticks, never inline `--body`/heredoc) and
+      PRINT THE PR URL in the chat
+- [ ] Update the roadmap row to `done · [#<pr>](<pr-url>)`
+- [ ] Commit `docs: link PR #<n>` and push
+```
+
+## El procedimiento
+
+1. **Elige la skill modificada** — la cuyo `SKILL.md` acabas de editar.
+2. **Configura el agente al modelo más débil de tu flota** — nombra el
+   suelo actual (Qwen3.6 35B / Gemma4 26B) si no tienes uno más débil
+   disponible; en caso contrario usa el que sea más débil en tu flota hoy.
+3. **Ejecuta la skill modificada contra el fixture**, siguiendo su
+   `SKILL.md` literalmente — sin ayuda extra, sin rellenar huecos que el
+   modelo debería rellenar por sí mismo.
+4. **Observa la salida** contra los criterios de aprobación fijos de
+   abajo.
+
+## Criterios de aprobación fijos
+
+Aprueba solo si **todas** las casillas se cumplen:
+
+- ✓ Cada bloque de salida fijo se imprime **exactamente** como se
+  contrató (bloques `Return exactly`, checklists, veredictos
+  `PASS | FAIL`, casillas del contrato de turno) — no parafraseado, no
+  renderizado parcialmente.
+- ✓ Se mantuvo la disciplina de rama y commit — ramificado desde `main`,
+  mensaje de commit convencional, nunca se trabajó directamente sobre
+  `main`.
+- ✓ **Sin pasos inventados** más allá de lo que declara el `SKILL.md` de
+  la skill.
+- ✓ Se imprimió el bloque de cierre `→ Next:`.
+
+Cualquier casilla sin marcar = **FAIL**. El arreglo es un ajuste de
+redacción de la skill (un cambio separado y dirigido) — según la nota de
+dirección de dependencia de la feature 08, este procedimiento solo saca a
+la luz la regresión, nunca edita la skill él mismo.
+
+## Registro de ejecuciones
+
+Una fila por ejecución. Añade una fila después de cada ejecución para que
+la cobertura se mantenga auditable a lo largo del tiempo.
+
+| Fecha | Modelo | Skill(s) + versión | Resultado | Nota |
+|------|-------|--------------------|--------|------|
+| 2026-07-10 | Qwen3.6 35B | `execute-phase` 1.x | PASS | fila de ejemplo — reemplazar en la primera ejecución real |
+
+## Límite de alcance
+
+Manual primero, sin CI, sin script ejecutable. Esto es deliberadamente lo
+más barato que detecta regresiones de modelo débil hoy. Gradúa a
+automatización solo si el procedimiento manual detecta regresiones
+repetidamente y el coste de mantenimiento se justifica — eso es una unidad
+separada y futura, no programada aquí.

--- a/docs/workflow/GOLDEN_FIXTURE.md
+++ b/docs/workflow/GOLDEN_FIXTURE.md
@@ -1,5 +1,7 @@
 # Golden fixture procedure
 
+> 🇪🇸 [Versión en español](GOLDEN_FIXTURE.es.md)
+
 A repeatable smoke test for skill wording: run a small, fixed toy feature
 through a changed skill **with the weakest model in your fleet**, and check
 its contracted output still holds. This is U9 of the 2026-07-09 backlog

--- a/docs/workflow/ISSUE_WORKFLOW.es.md
+++ b/docs/workflow/ISSUE_WORKFLOW.es.md
@@ -1,0 +1,118 @@
+# Flujo de trabajo de issues (de extremo a extremo)
+
+> 🇬🇧 [English version](ISSUE_WORKFLOW.md)
+
+Qué le pasa a un issue desde el momento en que aterriza hasta una decisión
+defendible y registrada. La skill central es `triage-issue`; los radios
+enrutan hacia fix, feature, o aplazamiento. Varios issues se pueden triar en
+un solo lote (`triage-issue 12 14 17`) — veredictos independientes, una sola
+tabla resumen; cualquier fix resultante sigue recibiendo su propia rama y PR.
+
+> Los comandos de forja de abajo usan `gh` (GitHub) — el ejemplo canónico.
+> Las **convenciones del flujo de trabajo** del proyecto declaran su forja;
+> en GitLab/Gitea ejecuta el equivalente de la CLI declarada.
+
+## Etapa 0 — Leer el issue y el proyecto
+
+`triage-issue` lee la guía del agente + el mapa de documentación, el índice
+de fixes (`docs/fix/README.md`) y la plantilla de SPEC de fix, el roadmap, y
+luego el propio issue en su totalidad (cuerpo, etiquetas, comentarios):
+
+```sh
+gh issue view <N> --json number,title,body,labels,state,comments
+```
+
+## Etapa 1 — Analizar el propio contrato del issue
+
+Los issues bien formados en este repositorio llevan sus propios criterios de
+decisión:
+
+- **Severidad** (p. ej. low/perf, low/maintainability).
+- Una cláusula de **"When to fix"** / **disparador** — a menudo basada en
+  señales ("revisit at the pagination milestone", "when a 3rd consumer
+  appears").
+- **"Acceptance (when triggered)"** — cómo se ve "hecho" *si* se dispara.
+
+Respeta ese contrato en lugar de actuar por reflejo.
+
+## Etapa 2 — Verificar el disparador contra el código ACTUAL
+
+Este es el paso que separa la evidencia de las corazonadas. Comprueba
+realmente:
+
+- Contar consumidores reales (`grep`) — ¿ya está realmente aquí el "tercer
+  consumidor"?
+- Comprobar un umbral — recuento de artículos/filas, latencia p95, tamaño de
+  bundle.
+- Reproducir un defecto reportado, o confirmar que ya está arreglado.
+
+Cita la evidencia (rutas, recuentos, referencias de línea) en la decisión.
+
+> Ejemplos ilustrativos:
+> - Un issue de rendimiento (una query sin límite en un camino caliente) —
+>   clasificado como `postpone` al archivarlo; se adelantó y se arregló una
+>   vez juzgado como una consulta cacheable y segura.
+> - Un helper duplicado entre dos módulos — el disparador es "un 3er
+>   consumidor"; se verificó que solo existen 2 → se mantuvo diferido con un
+>   comentario de **reconfirmación fechado**, nada implementado.
+
+## Etapa 3 — Clasificar y enrutar
+
+| Veredicto | Cuándo | Ruta |
+|---|---|---|
+| **fix-now** | Defecto, o el disparador se cumple | `plan-fix` → `execute-phase --fix`; añadir al índice de fixes |
+| **promote-to-feature** | Es realmente una capacidad nueva | `plan-feature <N>` (el router lleva el issue → SPEC acotado y **dimensionado**; las features pequeñas `XS/S` van solo con SPEC con ≥ 2 fases en el SPEC → `execute-phase <NN>`) |
+| **postpone** | Válido pero el disparador no se cumple | Dejar abierto; publicar comentario de reconfirmación fechado; **no implementar sobre la marcha** |
+| **wontfix** | Obsoleto o explícitamente acotado | Proponer cerrarlo con justificación |
+
+Si la decisión depende de un juicio de producto/riesgo en lugar de
+evidencia, presenta el veredicto + opciones y deja que el usuario decida
+antes de actuar.
+
+## Etapa 4 — El camino del fix (cuando es fix-now)
+
+`plan-fix` (persona de arquitecto senior) redacta
+`docs/fix/<N>-<topic>/SPEC.md` a partir del issue, lo acota estrictamente,
+expone bloqueadores/riesgos, lo registra en `docs/fix/README.md`, y confirma
+(commit) en una rama de fix — luego **se detiene para revisión**. Después
+`execute-phase --fix`:
+
+1. Asegura que el issue de GitHub existe (lo crea vía `gh issue create` si
+   falta).
+2. Verifica/crea la rama `fix/<N>-<topic>` (nunca `main`).
+3. Implementa el fix (el SPEC es el único artefacto de planificación — sin
+   fases).
+4. Ejecuta la puerta (chequeo de tipos, tests, build).
+5. **Marca el fix como `done` y abre el PR con `Closes #N` (siempre — nunca
+   solo-en-rama).** `done` significa construido, no fusionado.
+6. **`/review-change` obligatorio** (los hallazgos que no son fix-now →
+   `triage-issue`), luego `/audit-pr` como puerta de merge (nunca fusionar
+   con docs pendientes).
+7. **Solo después del merge:** elimina la entrada de
+   `docs/fix/README.md` — nunca antes (no dejes de rastrear el issue antes
+   de tiempo).
+
+## Etapa 5 — Informar y mantener los docs coherentes
+
+Sea cual sea el veredicto:
+
+- Publica la decisión como un **comentario fechado en el issue** con la
+  evidencia que comprobaste.
+- Si se convirtió en un fix activo → está en el índice de fixes; si se
+  fusionó/cerró → elimina la fila obsoleta del índice.
+- Nunca cambies el estado de GitHub (etiquetas, cierre) sin confirmación
+  cuando sea ambiguo.
+
+Una ejecución periódica de `audit-docs` detecta filas del índice de fixes
+cuyo issue ya se cerró, issues diferidos que silenciosamente se volvieron
+accionables, y desviaciones similares.
+
+## Ejemplo trabajado
+
+```
+/triage-issue  60
+   → reads "trigger = 3rd consumer of the shared helper"
+   → grep: only 2 modules import it  → trigger UNMET
+   → verdict: postpone
+   → gh issue comment 60  (dated re-confirmation, no code)
+```

--- a/docs/workflow/ISSUE_WORKFLOW.md
+++ b/docs/workflow/ISSUE_WORKFLOW.md
@@ -1,5 +1,7 @@
 # Issue workflow (end-to-end)
 
+> 🇪🇸 [Versión en español](ISSUE_WORKFLOW.es.md)
+
 What happens to an issue from the moment it lands to a defensible, recorded
 decision. The hub skill is `triage-issue`; the spokes route to fix, feature, or
 deferral. Several issues can be triaged in one batch (`triage-issue 12 14 17`) —

--- a/docs/workflow/MIGRATION.es.md
+++ b/docs/workflow/MIGRATION.es.md
@@ -1,0 +1,438 @@
+# Notas de migración
+
+> 🇬🇧 [English version](MIGRATION.md)
+
+## Ruta de actualización desde una instalación anterior a 2026-07-09
+
+El backlog de 2026-07-09/07-10 (11 unidades) trajo dos **cambios mayores**
+más varios cambios aditivos. Si tu instalación es anterior a ese backlog,
+sigue esta ruta ordenada una vez — las notas fechadas de abajo siguen
+siendo el registro detallado de cada paso; esta sección es solo el mapa.
+
+1. **`plan-feature` 2.0.0 — la definición de producto se separa en
+   `design-feature`.** La entrevista de idea-en-bruto y la checklist de
+   cierre de capacidades se movieron fuera de `plan-feature` a una skill
+   nueva, `design-feature`. `plan-feature` ahora es solo planificación de
+   ingeniería y **se niega a planificar una feature sin diseñar** (sin flag
+   de bypass) — en su lugar redirige a `/design-feature <slug>`. Cualquier
+   feature cuyo `SPEC.md` sea anterior a esta separación se lee como "sin
+   diseñar" la próxima vez que `plan-feature`/`execute-phase` la toque;
+   ejecuta `design-feature <slug>` una vez para rellenar la mitad de
+   producto. Ver
+   [la nota fechada](#2026-07-09--plan-feature-200-la-definición-de-producto-se-separa-en-design-feature)
+   de abajo para la tabla completa de memoria muscular de comandos.
+2. **El sobre-máquina se traslada a la capa de orquestación.** 14 skills
+   orientadas al usuario (todas menos `workflow-status`) dejaron de emitir
+   el bloque JSON `## Machine envelope` al final sin que se les pida. El
+   uso interactivo no se ve afectado; un driver/orquestador ahora inyecta
+   el fragmento canónico de system-prompt de `orchestration-envelope` e
+   implementa el bucle de reparación él mismo. Ver
+   [la nota fechada](#2026-07-10--el-sobre-máquina-se-traslada-a-la-capa-de-orquestación)
+   de abajo para lo que debe cambiar un driver.
+3. **Actualiza las skills, luego el sustrato.** `npx skills update` (o un
+   `npx skills add …` nuevo) solo refresca *comportamiento* de las skills.
+   Ejecuta **`init-workspace`** después — ahora detecta un andamiaje
+   existente y entra en **modo actualización**, proponiendo solo los
+   bloques de `template/` que le faltan a tu proyecto (máquina de cinco
+   estados del roadmap, revisión `--adversarial`, etc.) — nunca reescribe
+   un bloque que ya has personalizado.
+4. **Opcionalmente ejecuta `product-audit`** para ver qué *capacidades*
+   recién disponibles — no solo bloques de docs — aplican ahora a tu
+   código.
+
+Todo lo que sigue a partir de aquí es el registro fechado y detallado —
+lee una entrada específica cuando el resumen de arriba no dé suficiente
+contexto para actuar.
+
+## 2026-07-10 — `init-workspace` gana un modo de actualización para andamiajes existentes
+
+**Aditivo, no rompe nada.** `init-workspace` gana un segundo modo: en un
+repositorio que el Paso 0 reconoce como un andamiaje agentic-workflow
+existente (marcador: `CLAUDE.md` + `docs/features/ROADMAP.md` o
+`docs/workflow/`), ahora ofrece **actualizar** junto a las opciones
+existentes de fusionar/adaptar/abortar. El modo actualización obtiene el
+`template/` actual, compara el sustrato `CLAUDE.md`/`docs/` del proyecto
+contra él, lee este archivo (`MIGRATION.md`) para conocer el razonamiento
+detrás de cada bloque faltante, y propone **solo los bloques que le faltan
+al proyecto** mediante una entrevista corta, con valores por defecto
+descubiertos — nunca reescribe un bloque que el proyecto ya ha
+personalizado, y nunca borra nada. El modo bootstrap (un repositorio vacío
+o ajeno) queda idéntico byte a byte.
+
+**Por qué.** Actualizar las skills (`npx skills add …` / `npx skills
+update`) solo refrescaba siempre el *comportamiento*. Nada migraba el
+*sustrato* de un proyecto — el bloque `Docs site` (feature 01),
+`Performance commands` (02), la máquina de estados de cinco fases del
+roadmap (07), y cada otro bloque que una feature posterior añadió a
+`template/` seguía ausente en los proyectos que adoptaron el flujo de
+trabajo antes. `product-audit` podía detectar esa desviación pero nunca
+arreglarla (solo propone). El modo actualización cierra ese hueco.
+
+**Acción necesaria para instalaciones existentes.** Tras actualizar las
+skills, ejecuta `init-workspace` una vez — ahora detecta tu andamiaje
+existente y propone los bloques que te faltan en lugar de re-arrancar
+desde cero. Ver la sección "Updating an existing install" en `README.md` /
+`README.es.md` para la ruta ordenada completa (actualizar skills → leer
+este archivo → actualización de `init-workspace` → `product-audit`
+opcional). Nada se aplica sin confirmación; saltarte la ejecución deja tu
+sustrato exactamente como está hoy — sin regresión, solo sin los bloques
+más nuevos hasta que decidas incorporarlos.
+
+## 2026-07-10 — `review-change` gana `--adversarial N` opt-in
+
+**Aditivo, no rompe nada.** `review-change` añade un flag opt-in
+`--adversarial N`: N revisores adversariales independientes, de contexto
+limpio, solo-diff, se ejecutan en paralelo (subagentes de Claude Code /
+invocaciones headless / fallback de conversaciones nuevas secuenciales), y
+sus hallazgos se fusionan y deduplican por `file:line`+eje en la misma
+tabla de decisión única que la skill ya producía, con una columna de
+confianza `Reviewers n/N` y un umbral de inclusión de ≥1 revisor (sin
+quórum). **Sin flag → nada cambia** — el camino de un solo revisor por
+defecto es idéntico byte a byte a como era antes de que esta capacidad
+existiera. El modo también se **auto-recomienda (nunca se fuerza)** en la
+propia salida de `review-change` cuando un cambio es `L` o está marcado
+como sensible, y la etapa REVIEW no supervisada de `ship-roadmap` ahora
+**activa `--adversarial 2` como piso obligatorio** para features
+`L`/sensibles — una política deliberadamente distinta de (y no alineada
+con) esa recomendación interactiva, ya que una ejecución no supervisada no
+tiene ningún humano para ejercer el juicio de saltarla. Nada que migrar:
+ningún flag eliminado, ninguna forma de salida cambiada, ninguna acción
+requerida para que el uso existente siga funcionando. Ver
+`docs/workflow/REVIEW_AND_CLASSIFY.md` para el cuándo/cómo práctico.
+
+## 2026-07-10 — el sobre-máquina se traslada a la capa de orquestación
+
+**Cambio disruptivo al contrato de salida de 14 skills.** Cada skill
+orientada al usuario excepto `workflow-status` — `audit-docs, audit-pr,
+bump-skill, design-feature, execute-phase, generate-docs, init-workspace,
+log-session, plan-feature, plan-fix, product-audit, review-change,
+ship-roadmap, triage-issue` — ya no termina su turno con el bloque JSON
+entre comillas `## Machine envelope`. La casilla del contrato de turno que
+exigía esa emisión también se eliminó, y cada bloque de cierre `→ Next:`
+es ahora la salida genuinamente última del turno.
+
+**Por qué.** El único consumidor del sobre es un driver/orquestador
+externo; en chat interactivo el JSON al final era ruido, y los modelos
+débiles — que omiten obligaciones de fin de documento, según el propio
+razonamiento del flujo de trabajo para anteponer los contratos de turno —
+eran penalizados por omitir una obligación que una instrucción estática de
+`SKILL.md` nunca podía realmente aplicar ni recuperar. La aplicación ahora
+vive en la capa que lee el sobre: un driver puede detectar un sobre
+faltante y volver a preguntar, algo que el cuerpo de una skill no puede
+hacer por sí mismo.
+
+**Qué cambió:**
+
+- La sección `## Machine envelope` y su línea de contrato de turno se
+  eliminan de las 14 skills listadas arriba (subida MAJOR cada una — ver
+  `CHANGELOG.md`).
+- **`workflow-status` no cambia** — emitir el sobre en línea *es* su
+  función (`--json-only` no tiene sentido sin él); conserva la sección.
+- **`orchestration-envelope`** (interna, `user-invocable: false`) es ahora
+  el único hogar del contrato: gana el **fragmento canónico de
+  system-prompt inyectado por el driver** (textual, entre comillas) y
+  documenta el **bucle de reparación** (`parseEnvelope()` falla →
+  reinvocar la misma sesión con `Emit only the machine envelope for the
+  turn above.`; un reintento, luego un `FAILED` a nivel de driver). Subida
+  menor.
+- `docs/workflow/ORCHESTRATION.md` y `docs/workflow/PORTABLE_PROMPT.md`
+  reflejan el fragmento + el protocolo de bucle de reparación para autores
+  de drivers.
+- **El esquema JSON del sobre y el paquete npm
+  `@gtrabanco/agentic-workflow-schema` no cambian** — `parseEnvelope()` y
+  los drivers existentes siguen funcionando; solo cambió *quién* inyecta
+  el requisito, no el esquema que consumen.
+
+**Acción necesaria para drivers existentes.** Un driver que dependía de
+que cada skill emitiera el sobre sin que se le pidiera ahora debe inyectar
+el fragmento canónico de system-prompt (de `orchestration-envelope`) en
+sus invocaciones, e implementar el bucle de reparación para un turno que
+vuelve sin un sobre válido. `workflow-status` no necesita ningún cambio —
+sigue emitiendo en línea. Los drivers que ya inyectan su propio system
+prompt no pierden nada añadiendo este fragmento; los drivers sin
+mecanismo de inyección de prompt deberían añadir uno antes de actualizar
+más allá de este punto.
+
+## 2026-07-09 — el estado del roadmap se convierte en la máquina de estados del pipeline
+
+**No rompe nada, retrocompatible.** La columna `Status` del roadmap es
+ahora la única máquina de estados de verdad fundamental del pipeline —
+`idea → defined → planned → in-progress → done` — y la señal de puerta
+principal que lee cada sensor/ejecutor (`workflow-status`, la puerta de
+dependencias de `execute-phase`, la puerta de redirección de
+`plan-feature`). Antes solo existían `planned / in-progress / done`, lo
+que confundía una fila de lista de deseos escueta con una unidad
+completamente planificada y lista para ejecutar. El marcador
+`## Design status` local al SPEC (introducido por la separación de
+`design-feature` de arriba) se **conserva** como el registro local al SPEC
+y como el fallback de compatibilidad heredada descrito abajo — no se
+elimina.
+
+**Regla de compatibilidad heredada.** Una fila del roadmap anterior a este
+cambio — un estado `planned` simple sin historial `idea`/`defined` — cuya
+mitad de producto en `SPEC.md` está completa (`## Design status:
+designed`, cierre de capacidades relleno) se trata como
+**`defined`+`planned`**: es completamente ejecutable, no se dispara
+ninguna redirección, y no se requiere reetiquetado. Una fila `planned`
+heredada cuyo SPEC no tiene una mitad de producto completa (o no tiene
+SPEC en absoluto) se trata como `idea` y se redirige a
+`/design-feature <slug>` en su siguiente invocación de
+`execute-phase`/`plan-feature`.
+
+**Acción necesaria:** ninguna. Las filas existentes siguen funcionando
+bajo la regla de equivalencia de arriba. Los proyectos que quieran el
+historial explícito de cinco estados en filas antiguas pueden reetiquetar
+a mano, pero nada lo requiere.
+
+## 2026-07-09 — `plan-feature` 2.0.0: la definición de producto se separa en `design-feature`
+
+**Cambio disruptivo al contrato de `plan-feature`.** La definición de
+producto (la entrevista de idea-en-bruto, y la nueva checklist de
+**cierre de capacidades** que obliga a que cada entidad/capacidad/rol que
+introduce una feature llegue a su superficie completa — CRUD +
+transiciones de estado + UI + API + test, o un `n/a` explícito en tiempo
+de diseño) se movió fuera de `plan-feature` a una nueva skill orientada al
+usuario, **`design-feature`**. `plan-feature` ahora es **solo
+planificación de ingeniería**.
+
+**Qué cambió:**
+
+- **Skill nueva `design-feature`** (v1.0.0, `user-invocable: true`).
+  Incorpora la entrevista de idea-en-bruto, recorre el cierre de
+  capacidades, escribe la **mitad de producto** del SPEC, y sella
+  `## Design status: designed`. Las frases disparadoras "add feature" /
+  "add a feature" / "new feature" ahora aterrizan aquí, no en
+  `plan-feature`.
+- **`plan-feature` gana una puerta de redirección, sin flag de bypass.**
+  Dada una feature cuyo SPEC falta, o cuyo `## Design status` no es
+  `designed`, o cuya sección de cierre de capacidades está vacía,
+  `plan-feature` **SE DETIENE** e imprime `run /design-feature <slug>` en
+  lugar de planificarla. No hay ningún flag para saltarse esto — una
+  feature sin diseñar nunca se planifica en ingeniería.
+- **El paso interno de entrevista de idea-en-bruto que solía vivir dentro
+  del enrutamiento de `plan-feature` se retira** y se elimina del conjunto
+  de skills; su lógica ahora vive en `design-feature` (ver arriba). El
+  flag `--interview` de `plan-feature` ya no existe — pasa una idea en
+  bruto directamente a `design-feature` en su lugar.
+- **`docs/features/_TEMPLATE/SPEC.md`** ahora es **un SPEC en dos
+  mitades**: una **mitad de producto** (`design-feature` escribe:
+  contexto, objetivos de negocio, alcance, cierre de capacidades →
+  criterios de aceptación, herramientas, decisiones de producto,
+  `## Design status`) y una **mitad de ingeniería**
+  (`plan-feature-scaffold` escribe: objetivos técnicos, impacto en
+  arquitectura, diseño, decisiones a confirmar, requisitos de testing,
+  escenarios de desarrollo, fases, despliegue y rollback, entregables).
+  Sin `DESIGN.md` separado — esto fue un rechazo deliberado para evitar
+  que dos documentos se desviaran entre sí.
+- **`plan-feature-from-issue`** ahora escribe la mitad de producto del
+  SPEC y debe satisfacer el cierre de capacidades — un issue escueto se
+  entrega a `design-feature`, no es un atajo alrededor de la puerta.
+
+**Memoria muscular de comandos:**
+
+| Antes | Ahora |
+|---|---|
+| `plan-feature "<idea>"` / `--interview` | `design-feature "<idea>"`, luego `plan-feature <slug>` una vez `## Design status: designed` |
+| `plan-feature <slug>` (sin diseñar) | `plan-feature <slug>` ahora **se detiene y redirige** a `design-feature <slug>` — ejecuta eso primero |
+| `plan-feature <slug>` (ya diseñada) | sin cambios — enruta directamente al andamiaje de la mitad de ingeniería |
+| `plan-feature <N>` / `--from-issue N` | punto de entrada sin cambios; internamente ahora escribe la mitad de producto y satisface el cierre de capacidades antes de construir el andamiaje |
+
+**Acción necesaria:**
+
+- Si tenías memoria muscular de `plan-feature "<idea>" --interview`,
+  cambia a `design-feature "<idea>"` — `plan-feature` rechazará el
+  patrón de flag antiguo (ya no enruta una entrevista).
+- Si un proyecto tiene features cuyo `SPEC.md` es anterior a este cambio
+  (esquema de una sola mitad, sin `## Design status`), se leen como "sin
+  diseñar" bajo la nueva puerta la próxima vez que se invoque
+  `plan-feature` sobre ellas. Ejecuta `design-feature <slug>` una vez para
+  rellenar retroactivamente las secciones de la mitad de producto (el
+  cierre de capacidades se puede escribir retroactivamente a partir de los
+  criterios de aceptación existentes) antes de seguir planificando o
+  ejecutando — ver `docs/features/_TEMPLATE/SPEC.md` para el esquema
+  exacto de secciones contra el que rellenar.
+- La contabilidad de `bump-skill` ya está reflejada en `CHANGELOG.md` /
+  `CHANGELOG.es.md` y en las tablas de skills + modelos del README para
+  este cambio.
+
+## 2026-07-04 — v3: la rama por defecto se vuelve agnóstica de modelo
+
+**Cambio disruptivo a cómo instalas este flujo de trabajo** (no al
+comportamiento de ninguna skill). Antes de v3, `npx skills add
+gtrabanco/agentic-workflow` (sin `#ref`) instalaba la distribución con
+opinión propia: cada skill fijaba su propio frontmatter `model:`/`effort:`
+(Opus/high para skills de juicio, Sonnet/medium para las mecánicas, etc. —
+ver la tabla "Recommended model & effort" del README). Una rama separada
+`#inheritance`, auto-sincronizada por CI, eliminaba esas dos líneas de
+cada skill para poder instalarla agnóstica de modelo en su lugar.
+
+**v3 invierte cuál rama es la por defecto:**
+
+| Ref | Antes de v3 | Desde v3 |
+|---|---|---|
+| *(ninguna)* — `npx skills add gtrabanco/agentic-workflow` | con opinión propia, niveles de Claude fijados por skill | **agnóstica de modelo** — ninguna skill fija un nivel; cada una hereda el modelo/effort de la sesión anfitriona |
+| `#claude` | no existía | **nueva** — la distribución con opinión propia, ajustada por skill, que solía ser la por defecto; una instantánea congelada del `main` previo a v3, mantenida al día por CI desde `docs/workflow/model-routing.yml` |
+| `#inheritance` | agnóstica de modelo (eliminada de `main` por CI) | **sin cambios en el contenido**, ahora forzada (force-pushed) como espejo exacto de la rama por defecto (ya agnóstica de modelo); se conserva solo como un alias estable para quien la fijó antes de v3 |
+
+**Por qué:** usar este flujo de trabajo no debería atar un proyecto a la
+gama de modelos de un solo proveedor de IA. La disciplina (docs, SPECs,
+fases, revisión, la puerta de merge) es el producto; qué modelo la ejecuta
+no debería ser un valor por defecto oculto. Mover la responsabilidad de
+elegir el modelo correcto al usuario, con `#claude` todavía disponible
+para quien quiera los niveles de Claude ajustados a mano por skill, reduce
+ese coste de bloqueo sin eliminar la opción.
+
+**Acción necesaria:**
+
+- **¿Estás en Claude Code y dependes de los niveles por-skill de la
+  instalación por defecto?** Reinstala con `#claude`:
+  `npx skills add gtrabanco/agentic-workflow#claude`. Nada más cambia —
+  mismas skills, mismo comportamiento, solo los niveles que tenías antes
+  de v3.
+- **¿Ya fijaste `#inheritance`?** Nada que hacer. Sigue resolviendo, con
+  contenido idéntico al que siempre tuvo (ahora simplemente también es lo
+  que `main` sirve por defecto).
+- **¿En cualquier otro agente, o feliz eligiendo el modelo tú mismo?**
+  Nada que hacer — el comando de instalación simple ya te da esta rama.
+- **¿Mantienes un fork o una separación similar para tu propio proyecto?**
+  Ver `.github/workflows/sync-derived-branches.yml` para el patrón de CI
+  (espejo + inyección de frontmatter desde config), y
+  `docs/workflow/model-routing.yml` para la fuente de verdad de niveles
+  por skill.
+
+Ninguna instrucción, checklist, o contrato de salida de ninguna skill
+cambió en este release (ver las filas de subida de patch por skill
+fechadas 2026-07-04 en [`CHANGELOG.md`](../../CHANGELOG.md) — solo cambios
+mecánicos de frontmatter/descripción). Este es un cambio de modelo de
+distribución, no un cambio de comportamiento.
+
+## 2026-07-04 — `audit-pr` 2.0.0: auto-merge opt-in
+
+El contrato de `audit-pr` cambió de un incondicional **"nunca fusiona"** a
+**"nunca fusiona por defecto"**. Nada cambia para las configuraciones
+existentes — sin el opt-in se comporta exactamente como antes (veredicto
+de solo lectura, el humano fusiona). Qué hay de nuevo:
+
+- El encabezado del veredicto ahora siempre imprime la **URL completa del
+  PR** (no solo `#N`).
+- Si los docs del proyecto declaran una política de auto-merge (p. ej.
+  `merge: auto` / `merge: fullauto` en las convenciones del flujo de
+  trabajo o `SHIP_DECISIONS.md`), **o** el usuario lo instruye
+  explícitamente en la conversación, un veredicto MERGE-READY procede a
+  fusionar — pero solo después de una checklist pre-merge a prueba de
+  fallos: árbol limpio, nada sin empujar/sin traer, cabeza remota == SHA
+  auditado, CI verde y fresco en ese SHA, sin diff sensible/destructivo.
+  Cualquier cosa pendiente → no fusiona; enruta a confirmar+empujar,
+  espera a CI, y requiere una reauditoría fresca.
+
+**Acción necesaria:** ninguna, a menos que *quieras* auto-merge — entonces
+escribe la política en las convenciones del flujo de trabajo de tu
+proyecto. Si los docs de tu proyecto citan la frase antigua "never merges,
+never edits", actualízala a "never edits; merges only under a documented
+auto-merge policy".
+
+---
+
+# Migración — actualizar al conjunto de skills v2
+
+Si instalaste estas skills **antes del rediseño v2** (el conjunto de 9
+skills), esta página es la ruta de actualización. Tres skills fueron
+**renombradas**, así que una simple reinstalación actualiza las skills
+conservadas y añade las nuevas — pero deja atrás las tres carpetas
+antiguas. La CLI `skills` nunca elimina skills que desaparecieron de la
+fuente, así que tienes que eliminar esas tres tú mismo.
+
+> ¿Instalación nueva? Ignora esta página — solo sigue
+> [REPLICATE.es.md](REPLICATE.es.md).
+
+## Resumen rápido
+
+```sh
+# 1. Re-add: updates the 6 kept skills in place and installs the 8 new ones.
+npx skills add gtrabanco/agentic-workflow
+#   Private repo? Use the SSH URL (the shorthand can fail under bunx):
+#   npx skills add git@github.com:gtrabanco/agentic-workflow.git
+
+# 2. Remove the three renamed skills (the CLI won't prune them for you):
+npx skills remove design-feature draft-fix-spec feature-from-issue -y
+
+# 3. Verify:
+npx skills list
+```
+
+Eso es todo. Los comandos de arriba también funcionan con `--global` (si
+instalaste globalmente) y `--agent <name>` (para apuntar a un agente
+específico).
+
+## Qué cambió
+
+Las 9 skills orientadas al usuario se convirtieron en **13** en esa
+actualización (9 orientadas al usuario + 4 internas) — **14 hoy**, con la
+adición posterior del autopiloto `ship-roadmap` (10 orientadas al usuario
++ 4 internas). Nada se perdió — tres puntos de entrada de planificación
+**colapsaron en un router**, una skill fue **renombrada por simetría**, y
+se añadieron cuatro skills **nuevas** de calidad/automatización.
+
+| Estado | Skill | Acción al actualizar |
+|---|---|---|
+| 🔴 **Eliminada** (renombrada) | `design-feature` | **Borrar.** Su trabajo se movió al router `plan-feature` (camino de idea); el motor es el `plan-feature-interview` interno. |
+| 🔴 **Eliminada** (renombrada) | `feature-from-issue` | **Borrar.** Su trabajo se movió al router `plan-feature` (camino de issue); el motor es el `plan-feature-from-issue` interno. |
+| 🔴 **Eliminada** (renombrada) | `draft-fix-spec` | **Borrar.** Renombrada a `plan-fix`. |
+| 🟡 **Conservada** (mismo nombre) | `plan-feature` | Se actualiza en su lugar — **pero su significado cambió**: antes solo construía el andamiaje; ahora es el **router** (detecta idea / issue / slug acotado y despacha). El paso de andamiaje antiguo es ahora el `plan-feature-scaffold` interno. |
+| 🟡 **Conservada** (mismo nombre) | `execute-phase` | Se actualiza en su lugar. Ahora entrega el control a `review-change` cada 2 fases (checkpoint de revisión). |
+| 🟡 **Conservada** (mismo nombre) | `init-workspace` | Se actualiza en su lugar. Ahora también sugiere las skills de revisión complementarias de la plataforma. |
+| 🟡 **Conservada** (mismo nombre) | `review-implementation` | Se actualiza en su lugar. Ahora también es el motor que compone `review-change`. |
+| 🟡 **Conservada** (mismo nombre) | `audit-docs` | Se actualiza en su lugar. |
+| 🟡 **Conservada** (mismo nombre) | `triage-issue` | Se actualiza en su lugar. Ahora enruta fix-now → `plan-fix`, promote → `plan-feature`. |
+| 🟢 **Nueva** | `plan-fix` | Instalada por el re-add. La contraparte de flujo-de-fix de `plan-feature`. |
+| 🟢 **Nueva** | `review-change` | Instalada. Orquestador de revisión adaptable a la plataforma. |
+| 🟢 **Nueva** | `audit-pr` | Instalada. Puerta de merge a nivel de PR. |
+| 🟢 **Nueva** | `product-audit` | Instalada. Chequeo de salud periódico de todo el producto. |
+| 🟢 **Nueva** (interna) | `plan-feature-interview`, `plan-feature-from-issue`, `plan-feature-scaffold` | Instaladas pero ocultas del menú — solo el router `plan-feature` las invoca. |
+
+## Memoria muscular de comandos
+
+Tus comandos antiguos se mapean limpiamente al router:
+
+| Antes | Ahora |
+|---|---|
+| `/design-feature "<idea>"` | `/plan-feature "<idea>"` (el router detecta la idea → entrevista) |
+| `/feature-from-issue <N>` | `/plan-feature <N>` (el router detecta el issue → SPEC acotado) |
+| `/draft-fix-spec <N>` | `/plan-fix <N>` |
+| `/plan-feature <slug>` (andamiaje antiguo) | `/plan-feature <slug>` — **sin cambios**; el router detecta el slug acotado y construye el andamiaje |
+
+Así que en la práctica: donde antes recurrías a `design-feature` o
+`feature-from-issue`, simplemente llama a `plan-feature` y deja que
+enrute; `draft-fix-spec` se convierte en `plan-fix`.
+
+## Si `skills remove` no está disponible
+
+`npx skills remove` es la forma soportada de eliminar una skill instalada.
+Como alternativa, borra las carpetas directamente del directorio de skills
+de tu agente — para Claude Code eso es el `.claude/skills/` del proyecto
+(o `~/.claude/skills/` si instalaste con `--global`):
+
+```sh
+rm -rf .claude/skills/design-feature \
+       .claude/skills/draft-fix-spec \
+       .claude/skills/feature-from-issue
+```
+
+## Verifica el resultado
+
+Después de actualizar deberías ver **14 skills** (10 en el menú `/` + 4
+internas), y **ninguno** de los tres nombres eliminados:
+
+```sh
+npx skills list
+# expect: init-workspace, plan-feature, plan-fix, execute-phase,
+#         review-change, audit-pr, audit-docs,
+#         product-audit, triage-issue, ship-roadmap
+#         (+ the 4 internal steps: 3 plan-feature-* + review-implementation)
+# expect: NO design-feature, draft-fix-spec, feature-from-issue
+```
+
+Si los docs de un proyecto que configuraste antes todavía referencian los
+nombres antiguos, vuelve a ejecutar `init-workspace` (o `audit-docs`) para
+poner la copia de `docs/workflow/` de ese proyecto en línea con el
+conjunto v2.

--- a/docs/workflow/MIGRATION.md
+++ b/docs/workflow/MIGRATION.md
@@ -1,5 +1,7 @@
 # Migration notes
 
+> 🇪🇸 [Versión en español](MIGRATION.es.md)
+
 ## Upgrade path from a pre-2026-07-09 install
 
 The 2026-07-09/07-10 backlog (11 units) landed two **majors** plus several

--- a/docs/workflow/ORCHESTRATION.es.md
+++ b/docs/workflow/ORCHESTRATION.es.md
@@ -1,0 +1,358 @@
+# Orquestación programática — impulsar el flujo de trabajo sin Claude Code
+
+> 🇬🇧 [English version](ORCHESTRATION.md)
+
+Las skills del flujo de trabajo son instrucciones simples que cualquier
+agente puede seguir — pero dos comodidades de Claude Code hicieron que el
+*autopiloto* se sintiera nativo ahí: **`/loop`** (reinvocación automática) y
+**subagentes** (un contexto de modelo barato nuevo por fase). Ninguna forma
+parte del contrato. Este documento especifica el reemplazo neutral respecto
+al proveedor: un **driver externo** — un bucle de shell, un job de CI, tu
+propio programa — inyecta el requisito del sobre en cada invocación (ver
+abajo), analiza el **sobre-máquina** resultante (un bloque JSON fijo) de
+cada turno, y decide el siguiente comando y el modelo en el que ejecutarlo.
+
+```
+            ┌──────────────────────────────────────────────┐
+            │              YOUR ORCHESTRATOR                │
+            │  parse envelope → route on state → pick tier  │
+            └────────┬─────────────────────────▲────────────┘
+                     │ invoke (headless)       │ last fenced ```json block
+                     ▼                         │
+      agent session running ONE skill: workflow-status /
+      plan-feature / execute-phase / review-change / audit-pr / …
+```
+
+Esto es exactamente el bucle de `ship-roadmap` con el conductor movido
+fuera del agente — ganas la elección de nivel de modelo por paso (ejecuta
+`execute-phase` en un modelo barato, `audit-pr` en tu más fuerte) y no
+pierdes nada: las propias puertas de las skills (seguridad de rama, puerta
+de verificación, revisión obligatoria, puerta de merge) siguen aplicando
+dentro de cada paso.
+
+## El sobre
+
+Esquema completo en
+[`skills/orchestration-envelope/SKILL.md`](../../skills/orchestration-envelope/SKILL.md).
+Contrato en una línea: **el último bloque ```json entre comillas del
+mensaje final es el sobre; exactamente uno por turno; todas las claves de
+nivel superior siempre presentes.**
+
+### Analizándolo con el paquete oficial
+
+**`@gtrabanco/agentic-workflow-schema`** (npm) implementa el contrato:
+`parseEnvelope(text)` extrae el último bloque ```json entre comillas, lo
+valida, y devuelve un sobre completamente tipado; los ayudantes
+`isTerminal(state)` e `isRunHalt(envelope)` cubren las dos reglas de
+parada; el JSON Schema en bruto se exporta para drivers que no son JS. El
+código fuente vive en
+[`packages/agentic-workflow-schema/`](../../packages/agentic-workflow-schema/)
+y está bloqueado por versión a este contrato (ver su README).
+
+```ts
+import { parseEnvelope, isRunHalt, isTerminal } from "@gtrabanco/agentic-workflow-schema";
+const r = parseEnvelope(agentOutput);
+if (!r.ok) throw new Error(r.errors.join("; "));
+if (isRunHalt(r.envelope)) stopRun(r.envelope.blockers);
+else if (!isTerminal(r.envelope.state)) invoke(r.envelope.next.recommended, r.envelope.next.tier);
+```
+
+## Inyectar el requisito del sobre (fragmento de system-prompt + bucle de reparación)
+
+Desde la feature 10, el sobre ya no es una obligación del contrato de turno
+por-skill — cada skill orientada al usuario excepto `workflow-status`
+eliminó su sección `## Machine envelope` en línea, ya que el único
+consumidor es un driver como este, y una instrucción estática de `SKILL.md`
+no puede detectar ni recuperarse de una omisión de la forma en que puede
+hacerlo un driver. El contrato ahora vive aquí y en
+[`skills/orchestration-envelope/SKILL.md`](../../skills/orchestration-envelope/SKILL.md);
+un driver que quiera el sobre debe suministrarlo él mismo:
+
+1. **Inyecta el fragmento canónico de system-prompt** en cada invocación
+   headless (textual, de `orchestration-envelope/SKILL.md`):
+   ```text
+   Every turn you produce MUST end with exactly one fenced ```json block matching
+   the orchestration envelope schema (all top-level keys present; values only
+   from verified command output). Emit nothing after it.
+   ```
+2. **Bucle de reparación ante fallo de parseo.** Llama a
+   `parseEnvelope(lastTurn)` (`@gtrabanco/agentic-workflow-schema`) después
+   de cada invocación. Si falla — sin bloque json entre comillas, o no
+   valida — no trates el paso como fallido todavía: reinvoca la **misma
+   sesión** con el prompt de una línea
+   `Emit only the machine envelope for the turn above.` y analiza esa
+   respuesta. Razón: un modelo débil que omite el JSON al final de un
+   documento largo casi siempre lo produce cuando se le pide únicamente
+   eso — reparar por turno en la capa del driver es estrictamente más
+   fiable que una instrucción estática que el modelo siempre iba a saltarse.
+3. **Límite de reintentos.** Un intento de reparación por turno. Si la
+   respuesta de reparación tampoco se puede analizar, trata el paso como un
+   `FAILED` a nivel de driver y sácalo a la luz para un humano — no repitas
+   el prompt de reparación indefinidamente.
+4. **`workflow-status` no necesita bucle de reparación.** Es la única skill
+   que sigue emitiendo el sobre en línea (emitirlo es su función), así que
+   consultarla es una llamada normal sin fragmento inyectado ni paso de
+   reparación requerido.
+
+## La máquina de estados (enrutar por `state`)
+
+| `state` | Significado | Acción del orquestador | Nivel sugerido |
+|---|---|---|---|
+| `OK` | La skill terminó su trabajo | Invocar `next.recommended` | según `next.tier` |
+| `CONTINUE` | Misma unidad, más trabajo (siguiente fase / iteración) | Reinvocar `next.recommended` | `cheap` |
+| `READY_FOR_REVIEW` | Checkpoint o fin de unidad | `/review-change` | `strong` |
+| `READY_FOR_AUDIT` | Revisión limpia | `/audit-pr` | `strong` |
+| `MERGE_READY` | Auditoría aprobada; comentario publicado en el PR | El humano fusiona, o tu política fusiona (respeta la checklist pre-merge de la skill) | — |
+| `MERGED` | Auto-merge autorizado ejecutado | Siguiente unidad: `workflow-status` → enrutar | `cheap` (sensor) |
+| `NEEDS_FIXES` | Hallazgos fix-now / bloqueadores dentro de alcance | Ciclo de incorporación de `/execute-phase`, luego reejecutar la puerta que los emitió | `cheap` para incorporar, `strong` para repuerta |
+| `BLOCKED` | Dependencia no cumplida / causa externa | Seguir `dependencies.build_order` (planificar+ejecutar primero la unidad no cumplida más profunda) o resolver `blockers[]` | según el paso bloqueado |
+| `NEEDS_INPUT` | Se requiere una decisión humana | Mostrar `needs_input.question` + `options`; reanudar con la respuesta | — |
+| `FAILED` | Reintentos agotados (puerta en rojo, sustrato) | Detener esta unidad; un humano la revisa | — |
+| `HALT` | Descubrimiento de parar-el-mundo (`blockers[].scope: "run"`) | **Detener toda la ejecución**; sacarlo a la luz; nada más avanza | — |
+
+Piso de seguridad para cualquier driver, no negociable: **nunca saltarse
+una puerta `review_pending` o `audit_pending`, nunca fusionar salvo con un
+`MERGE_READY` fresco, y tratar `HALT` como terminal hasta que un humano lo
+despeje.** Las skills aplican esto dentro de cada paso; el driver no debe
+sortearlas.
+
+## El sensor: `workflow-status`
+
+Entre pasos (o para arrancar), ejecuta `workflow-status --json-only` —
+emite el estado completo del proyecto: cada feature/fix con su **cierre
+transitivo de dependencias** (cumplido/no cumplido), `startable_now`,
+`blocked_units` con órdenes de construcción, PRs abiertos con estado de
+auditoría, y hallazgos pendientes de triage. Enruta según
+`detail.startable_now` y `next.recommended`. Es de solo lectura y de nivel
+barato.
+
+## Urgencia: el micro-juicio pausar-vs-terminar (rúbrica canónica)
+
+El campo `detail.urgent` de `workflow-status` (feature 15) reporta issues
+abiertos que llevan las etiquetas `urgent`/`fix-next` protegidas por
+capacidad (leído **solo** del objeto de etiquetas, nunca del
+título/cuerpo/comentarios del issue — ver `skills/triage-issue/SKILL.md`,
+la única propietaria y escritora de ese vocabulario) — junto a los hechos
+de interrumpibilidad de la unidad en curso. Es un **sensor**: nunca decide
+si interrumpir. Esa decisión es esta rúbrica, ejecutada por el
+**consumidor** (un driver, la etapa SELECT de `ship-roadmap`, o un humano)
+— la única copia canónica que cada consumidor referencia, nunca bifurca.
+
+**Por qué es seguro alimentar al juez con el cuerpo del issue aunque esté
+controlado por un atacante:** la etiqueta ya condicionó *si* esta rúbrica
+se ejecuta siquiera — un issue sin etiqueta nunca llega a esta sección, sin
+importar lo que diga su texto. El juez solo elige entre dos caminos que la
+etiqueta ya autorizó (`INTERRUPT_NOW` ahora, o `FINISH_FIRST` e
+interrumpir después de esta fase); no puede escalar más allá de eso, y su
+peor fallo es un retraso acotado, nunca un fix perdido.
+
+**1 — Cortocircuito determinista (sin llamada al modelo, se ejecuta
+primero, siempre).** Evaluar de arriba a abajo; **la primera fila que
+coincide gana** — un issue `fix-next` nunca cae a las filas
+`INTERRUPT_NOW`/`FINISH_FIRST` de abajo, aunque el árbol de la unidad en
+curso resulte estar limpio.
+
+| Condición | Veredicto | Por qué no llamar al juez |
+|---|---|---|
+| `detail.urgent.issues` está vacío | — (no hay urgencia en juego) | Nada que decidir |
+| Un issue urgente lleva `fix-next` (no `urgent`) | Cabeza de la cola, **sin interrupción** | `fix-next` evita el juez por completo por diseño — nunca evalúa para interrumpir ahora |
+| `interruptibility.dirty == false` (árbol limpio, fase cerrada) | `INTERRUPT_NOW` | Interrumpir es gratis en un límite de commit — empieza el fix de inmediato |
+| `interruptibility.tasks_from_boundary <= 1` (a una casilla del cierre de fase) | `FINISH_FIRST` | Terminar casi no cuesta nada; interrumpir a mitad de una casilla cuesta más de lo que ahorra |
+
+Solo la **banda intermedia ambigua** — árbol sucio, más de una tarea del
+siguiente límite de commit, etiqueta `urgent` (no `fix-next`) — continúa al
+paso 2.
+
+**2 — El juez.** Una única invocación, cuatro guardarraíles, ninguno
+opcional:
+
+- **Sin herramientas.** El juez clasifica; no posee ningún efector de
+  ningún tipo. Darle herramientas reintroduciría exactamente la superficie
+  de inyección que las etiquetas existen para cerrar.
+- **Nivel barato, contexto limpio.** Genera una invocación nueva, de
+  contexto mínimo, en el nivel más barato capaz de tu flota — no un id de
+  nivel fijado aquí (el flujo de trabajo es agnóstico de modelo entre
+  70+ agentes); nunca el nivel que ejecuta la unidad en curso.
+- **Salida binaria cerrada + bucle de reparación de esquema.** La salida
+  completa del juez es:
+  ```json
+  {"verdict": "FINISH_FIRST | INTERRUPT_NOW", "reason": "<one line>"}
+  ```
+  Valida contra esa forma. No se puede analizar en el primer intento → una
+  invocación de reparación (`Emit only the verdict JSON for the case
+  above.`), la misma regla que el bucle de reparación del sobre visto
+  antes en este documento. Sigue sin poder analizarse tras la reparación →
+  **valor por defecto a prueba de fallos `FINISH_FIRST`** (ver abajo) —
+  nunca reintentar indefinidamente, nunca adivinar.
+- **Rúbrica como system-prompt.** La tabla de reglas de abajo **es** el
+  system prompt entregado al juez, textualmente — no una paráfrasis que el
+  juez asocia libremente. El juez la aplica como una checklist contra los
+  hechos específicos del issue + la interrumpibilidad que se le entregan, y
+  no devuelve nada más.
+
+  ```text
+  You are a bounded classifier. You have no tools and take no action — you
+  only classify. Given an urgent issue's content and the in-flight unit's
+  interruptibility facts, decide: interrupt the in-flight unit now, or finish
+  the current phase first?
+
+  Checklist (apply in order; first matching row wins):
+  1. Is the issue's real-world impact severe AND actively ongoing (data loss,
+     security exposure, broken production path) — not merely annoying or
+     already contained? If NO → FINISH_FIRST.
+  2. Is the in-flight unit more than one task from its next commit boundary
+     AND would interrupting lose uncommitted, hard-to-reconstruct work? If
+     YES → FINISH_FIRST.
+  3. Both the impact is severe/ongoing AND interrupting loses little (close to
+     a boundary, or the work is trivially resumable)? → INTERRUPT_NOW.
+  4. Uncertain, tied, or the evidence conflicts? → FINISH_FIRST (fail-safe
+     default — never guess toward interruption).
+
+  Output ONLY: {"verdict": "FINISH_FIRST | INTERRUPT_NOW", "reason": "<one
+  line>"}. Nothing before or after.
+  ```
+- **Valor por defecto a prueba de fallos `FINISH_FIRST`.** Ante cualquier
+  incertidumbre, empate, o salida no analizable que sobreviva al bucle de
+  reparación, el veredicto es `FINISH_FIRST` — nunca `INTERRUPT_NOW` por
+  defecto. La etiqueta ya garantiza que el fix se ejecuta a continuación de
+  cualquier forma; lo único en juego es *ahora* vs. *después de esta fase*,
+  así que errar hacia terminar nunca pierde un fix, solo acota un retraso.
+
+**3 — Actuar sobre el veredicto.** `INTERRUPT_NOW` → aparca la unidad en
+curso como un "crash" voluntario y limpio (commit de trabajo en curso +
+una nota en `progress.md` explicando por qué), luego ejecuta
+`plan-fix`/`execute-phase --fix` sobre el issue urgente; reanudar la
+unidad aparcada más tarde reutiliza el veredicto `RESUMABLE` de
+`workflow-status` + la re-entrada idempotente por fase de `execute-phase`
+— sin maquinaria nueva de aparcar/reanudar. `FINISH_FIRST` → termina el
+commit de la fase actual, luego el fix urgente es el siguiente en la cola
+(igual que el tratamiento de cabeza-de-cola de `fix-next`) antes de que
+empiece cualquier otra unidad.
+
+## Protocolo de reinicio del driver (recuperación ante caídas)
+
+Un proceso driver eventualmente morirá a mitad de turno. La regla de
+recuperación: **el estado persistido del driver es una pista; la verdad
+fundamental (git, forja, docs) es la fuente** — nunca "reparar" tu diario,
+recalcular desde la realidad.
+
+1. **Diario (forma recomendada).** Persiste cada sobre en modo
+   **solo-anexar**, una entrada por turno con una marca de tiempo y el SHA
+   de cabeza actual — nunca sobrescribir un único archivo de estado. La
+   última entrada es tu *hipótesis* al reiniciar; el log completo es tu
+   rastro de auditoría.
+2. **Al reiniciar**, llama al sensor con la hipótesis:
+   `workflow-status --json-only --last-envelope <last-entry.json>`
+   (agentes sin paso de argumentos: pega el JSON en el mensaje de
+   invocación — la skill lee el último bloque json entre comillas de la
+   solicitud como la pista).
+3. **Enruta según el sobre recalculado** — tres casos:
+   - `state: OK` (veredicto `CLEAN`) — sin interrupción; sigue
+     `next.recommended` como en cualquier tick normal.
+   - `state: CONTINUE` (veredicto `RESUMABLE`) — un turno murió a mitad de
+     fase pero el ledger apunta a una única tarea siguiente;
+     `next.recommended` es el comando de reanudación (`execute-phase <NN>
+     <phase>` re-entra idempotentemente — reconcilia las marcas de
+     `TASKS.md` contra la evidencia y continúa desde la primera tarea sin
+     marcar).
+   - `state: NEEDS_INPUT` (veredicto `AMBIGUOUS`) — el ledger contradice
+     los commits (marcas sin evidencia, rama desconocida); muestra
+     `needs_input.question` + `options` a un humano. No elijas
+     automáticamente.
+4. **Línea de divergencia.** El informe `Hint envelope: matched | diverged: …`
+   te dice si se completó trabajo después de tu última entrada de diario
+   (la realidad adelantada al diario es normal — una skill terminó y
+   empujó antes de la caída); adopta el estado recalculado y añádelo al
+   diario.
+
+Nada de lo anterior requiere acceso al sistema de archivos o a git en el
+propio driver — el sensor hace la lectura; el driver solo analiza sobres,
+que es el punto clave para drivers que solo hablan REST-API (p. ej. un
+servidor Node que habla con la API HTTP de un agente).
+
+## Reemplazando `/loop` (el bucle del driver)
+
+Invoca al agente en modo headless, una skill por invocación, y repite en
+bucle. La invocación es por-agente (`claude -p "…"` en el CLI de Claude
+Code; `opencode run "…"`; el modo no interactivo de cualquier agente;
+incluso un chat nuevo vía API) — el patrón es idéntico:
+
+```bash
+#!/usr/bin/env bash
+# Generic driver skeleton. AGENT_STRONG / AGENT_CHEAP are whatever commands
+# start a headless session on that tier for your agent(s) — they may even be
+# different agents/vendors per step.
+set -euo pipefail
+
+run() { # run <tier> <prompt> -> prints the envelope (last fenced json block)
+  local out; out="$("$@" 2>/dev/null)"
+  printf '%s\n' "$out" | awk '/^```json$/{f=1;j="";next} /^```$/{if(f){last=j};f=0} f{j=j $0 "\n"} END{printf "%s", last}'
+}
+
+while true; do
+  env_json="$(run $AGENT_CHEAP "Follow .agents/skills/workflow-status/SKILL.md with --json-only")"
+  state=$(jq -r .state <<<"$env_json"); next=$(jq -r .next.recommended <<<"$env_json")
+  tier=$(jq -r .next.tier <<<"$env_json")
+  case "$state" in
+    HALT|FAILED|NEEDS_INPUT) echo "$env_json" | jq .; exit 1 ;;
+    MERGE_READY)             echo "merge pending: $(jq -r .pr.url <<<"$env_json")"; exit 0 ;;
+    *) driver=$([ "$tier" = cheap ] && echo "$AGENT_CHEAP" || echo "$AGENT_STRONG")
+       env_json="$(run $driver "Follow the installed SKILL.md for: $next")" ;;
+  esac
+done
+```
+
+El esqueleto es deliberadamente mínimo — un driver real añade manejo por
+estado (ciclos de incorporación, recursión de orden de construcción en
+`BLOCKED`, política de merge en `MERGE_READY`) usando la tabla de arriba.
+El punto clave: **nada aquí es específico de Claude Code.**
+
+## Economía de la caché de prompts
+
+Cada llamada a `run()` de arriba es una invocación headless nueva — barata
+por diseño, pero solo si el driver no pelea contra la caché de prompts del
+proveedor del modelo:
+
+- **Mantén el system prompt / preámbulo estable byte a byte entre
+  invocaciones.** Misma skill → mismo prefijo, siempre (sin timestamp, id
+  de ejecución, u otro ruido por-llamada inyectado en la porción
+  cacheada). Un prefijo estable es lo que hace posible un acierto de
+  caché; un solo byte de deriva la invalida.
+- **Agrupa las invocaciones de una unidad dentro de una ventana corta.**
+  El TTL de la caché suele rondar los ~5 minutos — ejecutar los pasos de
+  una unidad seguidos mantiene la caché caliente; dejar huecos largos
+  entre pasos deja que expire y hay que pagar el precio completo de nuevo.
+- **Nunca cambies de modelo a mitad de unidad.** Más allá de invalidar la
+  caché (la caché de cada proveedor es específica del modelo), también
+  rompe la continuidad estilística entre los pasos de la unidad — elige el
+  nivel por paso (según la tabla de estados de arriba) pero manténlo fijo
+  durante todo el ciclo de vida de ese paso, sin cambiarlo a mitad de
+  camino.
+- **Un driver de una invocación por paso nunca necesita compactación en
+  absoluto** — ver `docs/workflow/FEATURE_WORKFLOW.md` →
+  *Higiene de contexto y coste* para saber por qué un contexto nuevo por
+  paso es el camino barato, no solo uno seguro.
+
+## Reemplazando subagentes (contextos baratos por fase)
+
+`ship-roadmap` genera un subagente de Claude Code por cada fase de
+`execute-phase` para ejecutar la implementación por debajo del nivel del
+conductor. El equivalente externo está integrado en el bucle de arriba:
+cada invocación `execute-phase NN Pk` ES una sesión headless nueva, y el
+driver elige el nivel barato para ella. Contexto nuevo por fase, modelo
+barato, la propia disciplina de `execute-phase` por dentro — las mismas
+propiedades, sin necesitar la primitiva de subagente.
+
+## Qué sigue siendo exclusivo de Claude Code (y su estado)
+
+| Característica | Estado |
+|---|---|
+| `/loop` | Comodidad. Completamente reemplazada por el bucle del driver de arriba. |
+| Subagentes | Comodidad. Reemplazados por una invocación headless por fase. |
+| Frontmatter `model:`/`effort:` por skill | Solo en la rama `#claude`; la rama por defecto hereda la sesión — el driver elige los niveles en su lugar. |
+| Ajuste de sesión `ultracode` | Acelerador opcional de Claude Code para el fan-out de ship-roadmap; sin equivalente necesario — un driver paraleliza ejecutando unidades independientes él mismo simultáneamente (respeta el flujo de git declarado del proyecto antes de paralelizar). |
+| Hooks de sesión de `.claude/` (captura de log-session) | Extra opcional; `log-session` invocado por el driver al final de la ejecución lo cubre. |
+
+`ship-roadmap` sigue siendo la forma *dentro del agente* de ejecutar este
+mismo bucle cuando prefieras no alojar un driver — los dos son
+equivalentes por diseño, y ambos consumen las mismas skills por debajo.

--- a/docs/workflow/ORCHESTRATION.md
+++ b/docs/workflow/ORCHESTRATION.md
@@ -1,5 +1,7 @@
 # Programmatic orchestration — driving the workflow without Claude Code
 
+> 🇪🇸 [Versión en español](ORCHESTRATION.es.md)
+
 The workflow's skills are plain instructions any agent can follow — but two
 conveniences of Claude Code made the *autopilot* feel native there: **`/loop`**
 (auto re-invocation) and **subagents** (a fresh cheap-model context per phase).

--- a/docs/workflow/PORTABLE_PROMPT.es.md
+++ b/docs/workflow/PORTABLE_PROMPT.es.md
@@ -1,17 +1,23 @@
-# Portable prompt — install the agentic workflow skill system
+# Prompt portable — instalar el sistema de skills del flujo de trabajo agéntico
 
-> 🇪🇸 [Versión en español](PORTABLE_PROMPT.es.md)
+> 🇬🇧 [English version](PORTABLE_PROMPT.md)
 
-Paste the prompt below into Claude Code (or any capable coding agent) **from the
-root of the target repository**. It regenerates the agentic workflow — **11
-user-facing skills + 3 internal steps** (minus `init-workspace`, which this
-prompt itself replaces as the bootstrap) — **adapted to that project's**
-architecture, documentation, and conventions, rather than copying this repo's
-specifics verbatim.
+Pega el prompt de abajo en Claude Code (o cualquier agente de programación
+capaz) **desde la raíz del repositorio destino**. Regenera el flujo de
+trabajo agéntico — **11 skills orientadas al usuario + 3 pasos internos**
+(menos `init-workspace`, que este mismo prompt reemplaza como el bootstrap)
+— **adaptadas a la** arquitectura, documentación, y convenciones **de ese
+proyecto**, en lugar de copiar textualmente los detalles de este
+repositorio.
 
-Use this when you want the skills tuned to a new project. For a deterministic,
-identical copy instead, install them with the `skills` CLI:
-`npx skills add gtrabanco/agentic-workflow` (see `REPLICATE.md`).
+Usa esto cuando quieras que las skills se ajusten a un proyecto nuevo. Para
+una copia determinista e idéntica en su lugar, instálalas con la CLI
+`skills`: `npx skills add gtrabanco/agentic-workflow` (ver `REPLICATE.es.md`).
+
+> **Nota sobre el idioma del prompt:** el bloque de abajo se deja
+> deliberadamente **sin traducir** — es un prompt literal, pensado para
+> pegarse tal cual en un agente; traducirlo cambiaría lo que el agente
+> ejecuta. Pégalo textualmente sin importar el idioma en el que trabajes.
 
 ---
 
@@ -212,12 +218,15 @@ created and how to use it.
 
 ---
 
-## Notes
+## Notas
 
-- The prompt is intentionally **discovery-driven**: it asks the agent to learn
-  each project's rules instead of hardcoding this repo's. That's what lets you
-  "work the same way" everywhere while still respecting each project's architecture.
-- After it runs, drive features with `plan-feature` (the router) and fixes with
-  `plan-fix`, execute with `execute-phase`, review with `review-change`, gate the
-  PR with `audit-pr`, and triage issues with `triage-issue` — exactly as
-  documented in `docs/workflow/`.
+- El prompt es intencionalmente **impulsado por el descubrimiento**: le
+  pide al agente que aprenda las reglas de cada proyecto en lugar de
+  codificar las de este repositorio. Eso es lo que te permite "trabajar de
+  la misma forma" en todas partes mientras sigues respetando la
+  arquitectura de cada proyecto.
+- Después de que se ejecute, impulsa las features con `plan-feature` (el
+  router) y los fixes con `plan-fix`, ejecuta con `execute-phase`, revisa
+  con `review-change`, aplica la puerta al PR con `audit-pr`, y clasifica
+  issues con `triage-issue` — exactamente como se documenta en
+  `docs/workflow/`.

--- a/docs/workflow/README.es.md
+++ b/docs/workflow/README.es.md
@@ -1,0 +1,70 @@
+# Flujo de trabajo agéntico
+
+> 🇬🇧 [English version](README.md)
+
+Cómo construimos con programación agéntica en este repositorio: el flujo de
+extremo a extremo para una **feature** y para un **issue**, las **skills**
+que impulsan cada paso, y cómo **replicar** todo el sistema en otro proyecto.
+
+Esta es la copia versionada, dentro del repositorio. Un espejo multi-página
+más amigable para el lector vive en Notion ("Agentic Workflow").
+
+## Páginas
+
+| Doc | Qué cubre |
+|---|---|
+| [FEATURE_WORKFLOW.es.md](FEATURE_WORKFLOW.es.md) | Idea/issue → SPEC + artefactos → ejecución por fases → hardening → review → audit → PR |
+| [ISSUE_WORKFLOW.es.md](ISSUE_WORKFLOW.es.md) | Triage → clasificar (fix-now / postpone / wontfix / promote) → enrutar → informar |
+| [SKILLS.es.md](SKILLS.es.md) | Cada skill del sistema, qué hace, y cómo se combinan |
+| [REVIEW_AND_CLASSIFY.es.md](REVIEW_AND_CLASSIFY.es.md) | Cuándo y cómo revisar — `review-change` (las revisiones correctas según la plataforma) y su motor `review-implementation` (encontrar → tabla de decisión clasificada) |
+| [RECOMMENDED_SKILLS.es.md](RECOMMENDED_SKILLS.es.md) | Skills agnósticas de calidad de software y arquitectura para una buena programación agéntica — universales vs. condicionales según la naturaleza del proyecto; las skills de stack/infraestructura quedan fuera de alcance |
+| [REPLICATE.es.md](REPLICATE.es.md) | Instalación con `npx skills` + prompt portable para configurar esto en cualquier proyecto |
+| [MIGRATION.es.md](MIGRATION.es.md) | Actualizar una instalación existente desde el conjunto de skills anterior — qué se renombró, qué eliminar |
+| [GOLDEN_FIXTURE.es.md](GOLDEN_FIXTURE.es.md) | Prueba de humo manual: tras editar una skill del camino ejecutor, correrla contra un fixture de juguete con el modelo más débil de la flota y comprobar que su salida contractual se mantiene |
+
+## Principios fundamentales
+
+1. **Los docs guían el trabajo.** Cada skill lee primero la guía propia del
+   proyecto (`CLAUDE.md`/`AGENTS.md`), el mapa de documentación, la
+   arquitectura, el roadmap y los docs de estilo, y los respeta. El flujo de
+   trabajo se adapta al proyecto, no al revés.
+2. **Planificar antes de programar.** Las features reciben un SPEC +
+   artefactos de planificación antes de escribir una sola línea.
+3. **Una fase a la vez.** La ejecución es fase a fase, cada una verificada y
+   confirmada (commit) por separado.
+4. **Un PR por unidad, siempre contra la rama por defecto.** Nunca trabajar
+   directamente sobre `main`; nunca apilar PRs.
+5. **Las decisiones se respaldan con evidencia.** El triage de issues
+   verifica los disparadores contra el código real; el trabajo diferido se
+   rastrea, no se implementa sobre la marcha.
+6. **Puerta de verificación antes de cada commit.** El chequeo de tipos, los
+   tests y el build deben pasar (usando los comandos de puerta propios del
+   proyecto).
+7. **Revisión a la altitud correcta.** El cambio (`review-change`), luego el
+   PR (`audit-pr`), y — periódicamente — el producto entero
+   (`product-audit`).
+
+## El mapa de un vistazo
+
+```
+                 ┌─────────────── ISSUE ───────────────┐
+                 │            triage-issue              │
+                 │   fix-now │ promote │ postpone │ wontfix
+                 └─────┬──────────┬──────────┬──────────┘
+                       │          │          └─ leave open + dated comment
+                       │          │
+              plan-fix │          │ plan-feature  (router takes the issue → SPEC)
+                       │          │
+                       ▼          ▼
+   FEATURE:   plan-feature ──▶ execute-phase ──▶ review-change ──▶ audit-pr ──▶ PR
+              (router:                            (auto every       (merge
+               idea│issue│scoped)                  2 phases)         gate)
+   FIX:        plan-fix ──▶ execute-phase --fix ──▶ review-change ──▶ audit-pr ──▶ PR
+
+   audit-docs ───── docs ↔ roadmap ↔ code ↔ fix index coherence            (anytime)
+   product-audit ── product-wide health check → issues + roadmap proposals (periodic)
+
+   AUTOPILOT:  ship-roadmap ── interview once ─▶ found + roadmap ─▶
+               /loop { the FEATURE chain above, feature by feature } ─▶ final report
+               (you merge the PRs — or --fullauto under safety floors)
+```

--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -1,5 +1,7 @@
 # Agentic workflow
 
+> 🇪🇸 [Versión en español](README.es.md)
+
 How we build with agentic programming in this repo: the end-to-end flow for a
 **feature** and for an **issue**, the **skills** that drive each step, and how to
 **replicate** the whole system in another project.

--- a/docs/workflow/RECOMMENDED_SKILLS.es.md
+++ b/docs/workflow/RECOMMENDED_SKILLS.es.md
@@ -1,0 +1,130 @@
+# Skills recomendadas — calidad de software y arquitectura agnósticas
+
+> 🇬🇧 [English version](RECOMMENDED_SKILLS.md)
+
+Esta lista corta es deliberadamente **agnóstica de stack**: skills que te
+ayudan a *programar bien con agentes* y elevan la **calidad de software y la
+arquitectura** en **cualquier** proyecto — sin importar el lenguaje, el
+framework, o la infraestructura. Apoyan y afinan nuestras skills del flujo
+de trabajo.
+
+> **Ninguna de estas es una dependencia.** El flujo de trabajo trae su
+> propio paquete de revisión interno (`skills/review-*`: código, seguridad,
+> verificación, deuda, diseño, a11y, marca, rendimiento, seo), así que
+> `review-change` / `product-audit` cubren cada eje de revisión por sí
+> solas, en cualquier agente y cualquier modelo. Todo lo de abajo es un
+> **extra opcional** que puede afinar un eje — nunca requerido para que el
+> flujo de trabajo funcione.
+
+> **Fuera de alcance a propósito:** skills de stack/infraestructura/servicio
+> (tu plataforma, framework, ORM, runtime, y paquetes de servicio/herramienta…).
+> Instala esas simplemente porque encajan con tu stack — te hacen más rápido
+> en *ese* stack, pero **no** son recomendaciones de calidad transversales.
+> Ver la sección de abajo.
+
+## Dos ejes de aplicabilidad
+
+- **Universal** — aplica a *todo* proyecto: CLI, librería, demonio, servicio,
+  web, móvil.
+- **Condicional según la *naturaleza* del proyecto** (no su stack) — aplica
+  según lo que el proyecto **es**. La prueba de fuego, generalizada a partir
+  del ejemplo de diseño: *"una skill de diseño es genial cuando hay algo que
+  diseñar — inútil para un programa de terminal (a menos que sea una app
+  TUI/`ink`, e incluso así suele ser excesivo)."* Pregunta **"¿hay
+  realmente un artefacto de este tipo que producir?"** antes de instalar.
+
+---
+
+## Universal — instalar en todo proyecto serio
+
+### A. Disciplina agéntica (programar *bien* con agentes)
+
+| Skill | Por qué | Combina con (nuestras) |
+|---|---|---|
+| `karpathy-guidelines` | Reduce los modos de fallo clásicos del agente: sobrecomplicación, ediciones no quirúrgicas, suposiciones no declaradas, criterios de éxito vagos. La skill de "programar bien con un agente" de mayor apalancamiento. | todas |
+| `skill-creator` (anthropic) | Autorar/mantener skills para que tu conjunto de herramientas agéntico se mantenga sano y consistente. | todas las nuestras |
+| `consolidate-memory` (anthropic) | Higiene periódica de memoria para que las notas de largo plazo del agente se mantengan veraces. | proyectos de larga duración |
+
+### B. Calidad de código & corrección
+
+| Skill | Por qué | Combina con (nuestras) |
+|---|---|---|
+| `code-review` | Bugs de corrección + simplificación sobre el diff. | `review-implementation` (añade la clasificación que le falta) |
+| `simplify` | Limpiezas de reutilización / simplificación / eficiencia / altitud — solo calidad, sin caza de bugs. | `review-implementation` |
+| `security-review` | Pase de seguridad sobre los cambios. | eje de seguridad de `review-implementation` |
+| `verify` | Ejecutar la cosa y confirmar el comportamiento real — no solo que los tests pasen. | `execute-phase` Etapa 4 |
+| `ghost-scan-secrets` | Escanea secretos/credenciales filtradas en cualquier código base. | "sin secretos" pre-commit |
+
+### C. Arquitectura & práctica de ingeniería
+
+| Skill | Por qué | Combina con (nuestras) |
+|---|---|---|
+| `engineering:architecture` | Guía & decisiones de arquitectura. | `plan-feature`, `review-implementation` (eje de arquitectura) |
+| `engineering:system-design` | Diseño de sistemas para features no triviales. | `design-feature`, `plan-feature` |
+| `engineering:testing-strategy` | Qué probar, en qué capa, cuánto. | ejes de test de `review-implementation`, testing de `execute-phase` |
+| `engineering:tech-debt` | Identificar & gestionar deuda deliberadamente. | `triage-issue`, `audit-docs` |
+| `engineering:debug` | Metodología sistemática de depuración. | cualquier trabajo de bugs |
+| `engineering:documentation` | Práctica de documentación. | `plan-feature`, `audit-docs` |
+| `doc-coauthoring` (anthropic) | Docs largos y estructurados: specs, propuestas, documentos de decisión. | `design-feature`, `plan-feature` |
+
+> **Skill de patrón de arquitectura:** mantén una que codifique *tu* patrón
+> elegido (puertos y adaptadores, arquitectura limpia, por capas, MVC…). El
+> patrón es agnóstico; la skill registra la decisión. Mantén una skill de
+> patrón de arquitectura por proyecto — reemplaza su contenido según el
+> proyecto, conserva la idea.
+
+---
+
+## Condicional — según lo que el proyecto *es* (no su stack)
+
+| Skill(s) | Instalar cuando el proyecto… | Saltar cuando… |
+|---|---|---|
+| `design-review`, `ux-audit`, `ux-extract`, `ux-compare`, `design-system`, `frontend-design` | …tiene una **UI de cara al usuario** que diseñar (app web, sitio de marketing, GUI de escritorio) | …es una CLI, librería, demonio, o backend/servicio puro — *a menos que* sea una app TUI/`ink` con maquetación real, e incluso así suele ser excesivo |
+| `web-perf` | …despliega un frontend **web** con Core Web Vitals que defender | …no es web |
+| `claude-api` | …**llama a la API de Claude / construye sobre el SDK de Anthropic** | …no tiene funciones de LLM |
+| `docx`, `pptx`, `xlsx`, `pdf`, `brand-guidelines`, `canvas-design` (anthropic) | …**produce esos artefactos como entregables** (informes, presentaciones, marca) | …tu salida es código fuente |
+
+**Regla de decisión:** la capacidad de la skill es irrelevante si el
+artefacto no está ahí. Sin UI → sin skills de diseño. Sin web → sin
+web-perf. Sin llamadas a LLM → sin claude-api. Sin documentos que entregar →
+sin skills de oficina.
+
+---
+
+## Cómo refuerzan estas nuestras skills del flujo de trabajo
+
+- **Planificar** — `engineering:system-design` + `doc-coauthoring` afinan
+  `plan-feature` (el router que cubre los caminos de entrada de idea, issue,
+  y slug acotado).
+- **Revisar** — `code-review` + `simplify` + `security-review` alimentan
+  los hallazgos de `review-implementation`; la nuestra añade la
+  **clasificación** que a ellas les falta.
+- **Decidir / deuda** — `engineering:tech-debt` ↔ `triage-issue`;
+  `audit-docs` mantiene honesto el conjunto de docs.
+- **Higiene agéntica** — `karpathy-guidelines` (cada tarea) + `skill-creator`
+  (mantener el conjunto de herramientas) + `consolidate-memory` (mantener la
+  memoria veraz).
+
+---
+
+## Fuera de alcance aquí — skills de stack / infraestructura / servicio
+
+Tus skills de plataforma/runtime, skills de framework, skills de
+ORM/base de datos, skills específicas de lenguaje, y los paquetes de
+servicio/herramienta `*:*` (pagos, chat, docs, control de versiones…).
+
+Instala estas **solo si** encajan con tu stack y servicios. Te hacen más
+rápido *en ese stack* — para este repositorio son la decisión correcta;
+para una CLI en Go o una librería en Rust son ruido. No forman parte de la
+recomendación de calidad agnóstica.
+
+---
+
+## En resumen
+
+En **cualquier** proyecto, instala el conjunto **Universal** (disciplina
+agéntica + calidad de código + arquitectura). Añade una skill
+**Condicional** solo cuando el proyecto tenga ese tipo de artefacto (UI,
+rendimiento web, LLM, documentos). Trata las skills de **stack/infra** como
+un eje separado y obvio — ajústalas a tu stack, no a la "calidad". Pocas
+skills de alta señal superan a muchas.

--- a/docs/workflow/RECOMMENDED_SKILLS.md
+++ b/docs/workflow/RECOMMENDED_SKILLS.md
@@ -1,5 +1,7 @@
 # Recommended skills — agnostic software quality & architecture
 
+> 🇪🇸 [Versión en español](RECOMMENDED_SKILLS.es.md)
+
 This shortlist is deliberately **stack-agnostic**: skills that help you *program
 well with agents* and raise **software quality and architecture** on **any**
 project — regardless of language, framework, or infrastructure. They support and

--- a/docs/workflow/REPLICATE.es.md
+++ b/docs/workflow/REPLICATE.es.md
@@ -1,0 +1,135 @@
+# Replicar en cualquier proyecto
+
+> 🇬🇧 [English version](REPLICATE.md)
+
+Replicar el flujo de trabajo tiene **dos mitades**: el **andamiaje** de
+documentación (el sustrato que leen las skills) y las **skills** mismas
+(el comportamiento).
+
+## Mitad 1 — el andamiaje de documentación (`template/`)
+
+Las skills operan sobre el sustrato de documentación de un proyecto: el
+mapa de documentación, las plantillas de SPEC/feature/fix, y las
+convenciones. Este repositorio distribuye ese sustrato como un andamiaje
+genérico y copiable en `template/`:
+
+```sh
+# Scaffold a new project's way of working (CLAUDE.md, docs/ tree, .github templates):
+npx degit gtrabanco/agentic-workflow/template my-project
+```
+
+Luego rellena los placeholders en `CLAUDE.md` (comandos, el mapa de
+documentación, tu arquitectura) y elimina las carpetas de docs que no
+necesites (p. ej. `frontend/` para un proyecto sin UI). Las skills leen
+este andamiaje en tiempo de ejecución, así que las dos mitades encajan.
+
+## Mitad 2 — las skills
+
+Dos formas de instalar las skills en un repositorio. Son complementarias.
+
+| Método | Qué obtienes | Cuándo usarlo |
+|---|---|---|
+| **CLI `skills`** | Las 15 skills (11 orientadas al usuario + 3 internas, más el contrato `orchestration-envelope`) copiadas (o enlazadas simbólicamente) **textualmente** en el directorio de skills del agente destino | Quieres exactamente las mismas skills, rápido, determinista, en cualquier agente |
+| **Prompt portable** | Las skills **regeneradas, adaptadas** a los docs/arquitectura del repositorio destino | Quieres que se ajusten a las convenciones de un proyecto distinto |
+
+El conjunto principal es **11 orientadas al usuario + 3 internas**:
+
+- **Orientadas al usuario (11):** `init-workspace`, `design-feature`,
+  `plan-feature`, `plan-fix`, `execute-phase`, `review-change`,
+  `audit-pr`, `audit-docs`, `product-audit`, `triage-issue`,
+  `ship-roadmap`.
+- **Internas (3):** `plan-feature-from-issue`, `plan-feature-scaffold` —
+  ocultas del menú e invocadas por el router `plan-feature`, que (una vez
+  diseñada una feature) detecta la entrada (issue → from-issue, slug/SPEC
+  acotado → scaffold) y despacha al motor correcto — más
+  `review-implementation`, el motor de hallazgos de dos fases encontrar →
+  clasificar que compone `review-change` (y que reutilizan `audit-pr` /
+  `product-audit`). La entrevista de idea-en-bruto que solía ser un paso
+  interno de `plan-feature` ahora está incorporada en la propia
+  `design-feature` (orientada al usuario, ya que la definición de
+  producto es su propia etapa).
+
+> **Versionado.** Cada skill lleva su propio `version:` (semver) en el
+> frontmatter; los cambios se registran en
+> [`../../CHANGELOG.md`](../../CHANGELOG.md). Actualiza una instalación
+> con `npx skills update`.
+
+## Método 1 — CLI `skills` (determinista)
+
+La CLI [`skills`](https://github.com/vercel-labs/skills) lee los archivos
+`SKILL.md` directamente de este repositorio y los instala en el agente que
+uses. Detecta automáticamente los agentes instalados (Claude Code, Cursor,
+Codex, OpenCode, Cline, y [70+ más](https://skills.sh)) y escribe cada
+skill en el directorio de skills de ese agente — `.claude/skills/` para
+Claude Code, `.agents/skills/` para el conjunto universal, etc.
+
+```sh
+# From the root of the TARGET repository — install all skills:
+npx skills add gtrabanco/agentic-workflow
+
+# This repo is PRIVATE. The shorthand above can fail under bunx; use the SSH URL:
+npx skills add git@github.com:gtrabanco/agentic-workflow.git
+
+# Useful flags:
+#   --skill <name>     install only specific skills (repeatable)
+#   --agent <name>     target specific agents (repeatable; e.g. claude-code, cursor, codex)
+#   --global, -g       install for the current user instead of the current project
+#   --copy             copy files instead of symlinking
+#   --list, -l         list the skills the source exposes, then exit
+#   --yes, -y          non-interactive
+
+# Manage them afterwards:
+npx skills list
+npx skills update
+npx skills remove <name>
+```
+
+Sin publicación en npm, sin registro, sin paso de build — la CLI clona el
+repositorio y coloca las carpetas de skills para cada agente. Añadir una
+skill a este sistema es solo añadir un `skills/<name>/SKILL.md`; la CLI la
+detecta automáticamente sin ningún manifiesto que mantener.
+
+Tras instalarlas, las skills funcionan de inmediato porque **descubren el
+proyecto destino en tiempo de ejecución** (guía del agente, mapa de
+documentación, arquitectura, roadmap, índice de fixes). Nada en ellas está
+codificado a las rutas de este repositorio.
+
+> **Skill individual / ref distinta.** La fuente acepta una ruta a una
+> sola skill (`.../tree/main/skills/plan-feature`), una URL git completa,
+> o una ruta local (`npx skills add ./path/to/agentic-workflow`). Ver el
+> README de `skills` para todos los formatos de fuente.
+
+## Método 2 — Prompt portable (adaptativo)
+
+[`PORTABLE_PROMPT.es.md`](PORTABLE_PROMPT.es.md) contiene un prompt que
+pegas en Claude Code (o cualquier agente de programación capaz) desde la
+raíz del repositorio destino. Este:
+
+1. Descubre las convenciones de ese proyecto (reglas de rama, comandos de
+   puerta, idioma de docs, esquema de SPEC/roadmap/fix, arquitectura,
+   estilo).
+2. Crea las skills adaptadas a esas convenciones.
+3. Escribe una copia de `docs/workflow/` usando las rutas y comandos
+   reales del proyecto.
+4. Se combina con cualquier skill de ejecución/revisión que ya exista ahí.
+
+Usa esto cuando la estructura del proyecto destino difiera lo suficiente
+como para que prefieras que las skills se reajusten en lugar de copiarse.
+
+## ¿Cuál debería usar?
+
+- Mismo stack / repositorio similar → **CLI `skills`** (Método 1). Las
+  skills se adaptan en tiempo de ejecución de todas formas.
+- Stack distinto, o quieres que la copia de docs/workflow esté escrita en
+  los propios términos del proyecto → **prompt** (Método 2).
+- Cinturón y tirantes → instala con la CLI, luego ejecuta `audit-docs`
+  para confirmar que las skills encajan con los docs del proyecto nuevo.
+
+## Qué significa "respetar el proyecto" aquí
+
+Ambos métodos producen skills que, en tiempo de ejecución, **leen y
+obedecen** las reglas de arquitectura, el mapa de documentación, las guías
+de estilo, las convenciones de nombres, las reglas de
+dinero/i18n/SEO/a11y/seguridad, y la puerta de verificación **del proyecto
+destino**. La forma del flujo de trabajo se mantiene constante; los
+detalles siempre vienen del proyecto en el que estás.

--- a/docs/workflow/REPLICATE.md
+++ b/docs/workflow/REPLICATE.md
@@ -1,5 +1,7 @@
 # Replicate in any project
 
+> 🇪🇸 [Versión en español](REPLICATE.es.md)
+
 Replicating the workflow has **two halves**: the documentation **scaffold** (the
 substrate the skills read) and the **skills** themselves (the behavior).
 

--- a/docs/workflow/REVIEW_AND_CLASSIFY.es.md
+++ b/docs/workflow/REVIEW_AND_CLASSIFY.es.md
@@ -1,0 +1,125 @@
+# Revisar & clasificar — `review-change` + `review-implementation`
+
+> 🇬🇧 [English version](REVIEW_AND_CLASSIFY.md)
+
+Cómo revisar un cambio. **`review-change`** es el **orquestador**
+adaptable a la plataforma: ejecuta solo las revisiones que aplican a este
+proyecto + cambio y sintetiza un informe. **`review-implementation`** es su
+**motor de hallazgos** — la revisión de dos fases, **sin refactorizar**, que
+termina en una **tabla de decisión clasificada**. Recurre a `review-change`
+para la revisión completa y del tamaño correcto; llama a
+`review-implementation` directamente para un pase clasificado rápido. Las
+especificaciones completas viven en las skills
+(`.claude/skills/review-change/SKILL.md`,
+`.claude/skills/review-implementation/SKILL.md`); esto es el cuándo/cómo
+práctico.
+
+## Cuándo usarla
+
+- **Etapa 4 del flujo de trabajo de features** — sobre la rama completa,
+  justo antes de abrir el PR.
+- **A mitad de la feature**, cuando quieres una lectura clasificada de qué
+  está mal y qué hacer realmente al respecto (no solo una lista plana de
+  bugs).
+- Siempre que de otro modo ejecutarías tus dos prompts manuales — *"revisa
+  por X, Y, Z — solo hallazgos"* y luego *"clasifica esos hallazgos en una
+  tabla de decisión"*. Esta skill colapsa ambos en un solo pase.
+- Antes de un corte de release o tras un refactor grande.
+
+**No es para:** arreglar código realmente (nunca refactoriza), ni para la
+puerta rutinaria de tipos/tests/build — eso es la puerta de verificación del
+proyecto (chequeo de tipos, tests, build).
+
+## Cómo invocarla
+
+- `/review-change` — el orquestador: ejecuta los ejes aplicables a esta
+  plataforma y sintetiza una tabla + una checklist de verificación manual.
+  Úsala antes de un PR.
+- `/review-implementation` — solo el motor; por defecto usa el **diff de la
+  rama actual frente a `main`**.
+- Pasa una ruta/glob para ampliar o acotar el alcance, p. ej.
+  *"review-implementation sobre src/payments/"*.
+- Ambas imprimen el **alcance** al principio, para que sepas qué se cubrió y
+  qué no.
+
+## Qué produce (dos fases, sin refactorizar)
+
+**Fase 1 — Encontrar.** Hallazgos (id + `file:line` + evidencia) a lo largo
+de: bugs, violaciones de arquitectura, código eliminable/muerto,
+seguridad/ciberseguridad, incompatibilidades de plataforma/runtime,
+sobre-ingeniería y optimización prematura, riesgo de tamaño de bundle, y
+tests (fallando **y** faltantes) — más cualquier violación de las reglas del
+proyecto (lo que mandaten sus docs).
+
+> **Excepción de código muerto:** el código deliberadamente preparado para
+> una feature en curso o planificada **no** está muerto. La skill
+> contrasta el roadmap, el SPEC/`TASKS.md` de la feature, y
+> `known-issues.md`; si no puede saberlo, marca el hallazgo como *verify* y
+> pregunta — nunca afirma "muerto" por conjetura.
+
+**Fase 2 — Clasificar.** Cada hallazgo aterriza en una tabla de decisión:
+
+| Hallazgo | Eje | Sev | Clase | PORQUÉ | Riesgo de impl. | Impacto a largo plazo | ¿Opt. prematura? | Ruta |
+|---|---|---|---|---|---|---|---|---|
+| Query sin límite en camino caliente | perf | low | postpone | Insignificante ahora | Bajo (caché) | Crece con los datos | no | issue + disparador |
+| Helper duplicado en 2 archivos | mantenibilidad | low | intentional-tradeoff | Acoplar 2 features es peor | — | Divergencia casi nula | no | documentar en el código |
+| Secreto confirmado en un archivo de config | seguridad | high | fix-now | Exposición de credenciales | Bajo (mover a gestor de secretos) | Riesgo de incidente | no | plan-fix |
+| Módulo nuevo sin tests | tests | med | fix-now | Camino de fallo sin probar | Bajo | Riesgo de regresión | no | incorporar a la fase |
+
+Clases: **fix-now / postpone / ignore / intentional-tradeoff**.
+
+## Qué haces con el resultado
+
+`review-change` es **obligatoria antes de cada merge** (cada unidad la
+recibe), y ejecuta **cada hallazgo no-fix-now a través de `triage-issue`**
+para que cada uno tenga un destino real — nunca se pierde en silencio:
+
+- **fix-now** → `plan-fix` → `execute-phase --fix` (o se incorpora a la
+  fase de feature actual si es trabajo aún sin fusionar).
+- **postpone** → `triage-issue` → issue rastreado **con un disparador**. No
+  implementar sobre la marcha.
+- **intentional-tradeoff** → `triage-issue` → documentarlo (comentario en
+  el código, `decisions.md`, o un issue) para que no se vuelva a marcar en
+  la próxima revisión.
+- **ignore** → `triage-issue` → anota el razonamiento (o confirma que no
+  necesita nada).
+
+Luego imprime el siguiente paso (limpio → `/audit-pr`).
+
+## Multi-revisor adversarial (opt-in)
+
+`review-change --adversarial N` ejecuta **N revisores independientes, de
+contexto limpio, solo-diff** — cada uno con la postura adversarial estándar
+de "asumir que el diff está mal" — en paralelo, y luego fusiona y
+deduplica sus hallazgos por `file:line` (+eje) en la misma tabla de decisión
+clasificada de arriba. Un hallazgo levantado por **≥1** revisor se incluye;
+no hay puerta de mayoría/quórum, porque todo el punto es detectar lo que a
+un revisor se le escaparía.
+
+- **Tres niveles de despliegue**, adaptables a la plataforma: Claude Code →
+  N **subagentes** en paralelo; un agente con invocación headless → N
+  **invocaciones headless** en paralelo; ninguno de los dos → N
+  **conversaciones nuevas secuenciales** (más lento, el fallback documentado
+  de último recurso).
+- **Desactivado por defecto.** Sin flag → el comportamiento actual de un
+  solo revisor, sin cambios. `review-change` **auto-recomienda** el modo
+  (nunca lo fuerza) para cambios `L` o marcados como sensibles (auth, pagos,
+  migraciones destructivas, secretos, config de CI) — el usuario decide si
+  la seguridad extra vale el coste.
+- **Nota de coste: 2–3× la etapa de revisión más cara**, porque N revisores
+  ejecutan cada uno el motor de hallazgos completo. Ese coste es exactamente
+  por qué el modo permanece opt-in para uso interactivo.
+- **`ship-roadmap` lo activa como piso obligatorio** — `--adversarial 2`
+  para features `L`/marcadas como sensibles en su etapa REVIEW no
+  supervisada, porque no hay ningún humano presente para ejercer el juicio
+  de saltarla en el que se apoya el aviso interactivo. Este piso
+  deliberadamente **no está alineado** con el aviso interactivo (que sigue
+  siendo opt-in) — los dos sirven contextos distintos a propósito.
+
+## Dónde encaja
+
+Etapa 4 (verificación & revisión), junto a `/code-review`,
+`/security-review`, `/verify`. Añade la **clasificación + los ejes
+conscientes del proyecto** que aquellas no tienen, en un solo pase. Enruta
+`fix-now` hacia `plan-fix`, y **cada hallazgo no-fix-now** (postpone / ignore
+/ intentional-tradeoff) hacia `triage-issue`.

--- a/docs/workflow/REVIEW_AND_CLASSIFY.md
+++ b/docs/workflow/REVIEW_AND_CLASSIFY.md
@@ -1,5 +1,7 @@
 # Review & classify — `review-change` + `review-implementation`
 
+> 🇪🇸 [Versión en español](REVIEW_AND_CLASSIFY.es.md)
+
 How to review a change. **`review-change`** is the platform-adaptive
 **orchestrator**: it runs only the reviews that apply to this project + change and
 synthesizes one report. **`review-implementation`** is its **findings engine** —

--- a/docs/workflow/SKILLS.es.md
+++ b/docs/workflow/SKILLS.es.md
@@ -1,0 +1,211 @@
+# Referencia del sistema de skills
+
+> 🇬🇧 [English version](SKILLS.md)
+
+Las skills que componen el flujo de trabajo agéntico, agrupadas por rol.
+
+**14 skills orientadas al usuario** (una entrada de menú cada una) + **14 pasos
+internos** compuestos por ti (los dos pasos de planificación del router
+`plan-feature`, el motor de hallazgos `review-implementation` de
+`review-change`, el contrato `orchestration-envelope`, el paquete de revisión
+interno de 9 skills del propio flujo de trabajo: `review-code`,
+`review-security`, `review-verify`, `review-debt`, `review-design`,
+`review-a11y`, `review-brand`, `review-perf`, `review-seo`, y el ayudante de
+mantenimiento `bump-skill` propio del repositorio). De las 14: 12 skills del
+flujo de trabajo principal, un ayudante de diario `log-session`, y un sensor
+de solo lectura `workflow-status`.
+
+## Configuración
+
+| Skill | Rol | Entrega a |
+|---|---|---|
+| `init-workspace` | Obtiene el andamiaje de `template/` y lo adapta al proyecto mediante entrevista; sugiere las skills de revisión complementarias de la plataforma; ofrece instalar las skills | `design-feature` |
+
+## Diseño
+
+| Skill | Rol | Entrega a |
+|---|---|---|
+| `design-feature` | **Definición de producto.** Incorpora la entrevista de idea-en-bruto, ejecuta investigación proporcional, y recorre la checklist de **cierre de capacidades** (por entidad → CRUD + transiciones de estado + UI + API + test o `n/a` explícito; por capacidad → punto de entrada + ACL; por rol → asignar/revocar/ver) hasta convertirla en criterios de aceptación exhaustivos. Escribe la **mitad de producto** del SPEC y sella `## Design status: designed`. Hace upsert al reejecutarse; nunca destruye decisiones registradas | `plan-feature <slug>` |
+
+## Planificación
+
+| Skill | Rol | Entrega a |
+|---|---|---|
+| `plan-feature` | **Router, solo planificación de ingeniería.** Dada una feature sin diseñar (sin `## Design status: designed`), **SE DETIENE y redirige** a `/design-feature <slug>` (sin flag de bypass). Dada una feature/issue diseñada `#N` (issue → mitad de producto acotada → `design-feature` para issues escuetos), enruta a rellenar la **mitad de ingeniería**, **dimensiona la feature** (`XS/S/M/L`), y luego registra la entrada del roadmap | `execute-phase <NN> P1` (M/L y XS/S por igual — las fases XS/S viven en el SPEC) |
+| `plan-fix` | Redacta como arquitecto un SPEC de fix estrechamente acotado a partir de un issue; confirma en una rama de fix; se detiene para revisión | `execute-phase --fix` |
+
+### Pasos internos (ocultos del menú; compuestos por ti)
+
+| Skill | Rol |
+|---|---|
+| `plan-feature-from-issue` | Issue de solicitud de feature → mitad de producto del SPEC acotada (satisface el cierre de capacidades), con `Closes #N` (invocado por `plan-feature`) |
+| `plan-feature-scaffold` | Rellena la **mitad de ingeniería** del SPEC + artefactos de planificación **escalados al tamaño de la feature** (XS/S → solo SPEC; M/L → conjunto completo terminando en una fase de hardening obligatoria); registra en el roadmap (solo docs) (invocado por `plan-feature`) |
+| `review-implementation` | Encontrar → clasificar → tabla de decisión en dos fases (fix-now / postpone / ignore / intentional-tradeoff); solo hallazgos, sin refactorizar. `user-invocable: false` — el motor que compone `review-change` (y que reutilizan `audit-pr` / `product-audit`) |
+| `orchestration-envelope` | El contrato del sobre-máquina: fragmento canónico de system-prompt inyectado por el driver, bucle de reparación, y esquema JSON. `user-invocable: false` — la pieza que inyecta un driver externo, no una entrada de menú |
+| `review-code` | Checklist de corrección + reutilización/simplificación/eficiencia sobre el diff. `user-invocable: false` — un eje del paquete de revisión interno de `review-change` |
+| `review-security` | Checklist de seguridad con forma OWASP sobre el diff. `user-invocable: false` — paquete de revisión interno |
+| `review-verify` | Checklist de verificación de comportamiento en tiempo de ejecución (¿el cambio realmente hace lo que promete?). `user-invocable: false` — paquete de revisión interno |
+| `review-debt` | Checklist de deuda técnica / TODO / código muerto sobre el diff. `user-invocable: false` — paquete de revisión interno |
+| `review-design` | Checklist de consistencia arquitectónica/de capas sobre el diff. `user-invocable: false` — paquete de revisión interno |
+| `review-a11y` | Checklist de accesibilidad sobre cambios de UI. `user-invocable: false` — paquete de revisión interno |
+| `review-brand` | Checklist de consistencia de marca/voz sobre el texto de cara al usuario. `user-invocable: false` — paquete de revisión interno |
+| `review-perf` | Checklist de regresión de rendimiento sobre el diff. `user-invocable: false` — paquete de revisión interno |
+| `review-seo` | Checklist de SEO sobre páginas/rutas públicas. `user-invocable: false` — paquete de revisión interno |
+
+## Ejecución
+
+| Skill | Rol |
+|---|---|
+| `execute-phase` | Ejecuta una fase de feature (por defecto), una feature `XS/S` pequeña en un solo pase, o un fix (`--fix`); **tests primero** en trabajo de dominio/orquestación, nunca confirma en rojo, en P1 confirma los artefactos de planificación por separado; seguridad de rama + disciplina de docs por fase + puerta; **recomienda un checkpoint de `review-change` cada 2 fases (se puede saltar) y entrega el control una vez al final (obligatorio)**; una unidad terminada **siempre abre su PR y pasa a `done`** (construida, no fusionada) |
+
+## Review & audit — *cambio → PR → producto*
+
+| Skill | Alcance | Rol | Entrega a |
+|---|---|---|---|
+| `review-change` | el **cambio** | Ejecuta solo las revisiones que aplican a esta plataforma + una **comprobación de desviación del SPEC** (diff vs. el alcance y los criterios de aceptación del SPEC) + clasifica → una tabla de decisión + checklist de verificación manual; **obligatorio antes de cada merge** | `plan-fix` (fix-now) / `triage-issue` (cada hallazgo no-fix-now: postpone / ignore / intentional-tradeoff) |
+| `audit-pr` | el **PR** | Puerta de merge: aceptación, fases, docs, tests, CI, `Closes #N`, ejes de revisión → merge-ready o bloqueadores | `execute-phase` / `plan-fix` / `triage-issue` |
+| `product-audit` | el **producto** | Chequeo de salud periódico de espectro completo; extrae de los docs de feature → propone issues + cambios de roadmap (nunca arregla automáticamente) | `triage-issue` / `plan-feature` / `plan-fix` |
+| `audit-docs` | los **docs** | Audita docs ↔ roadmap ↔ código ↔ índice de fixes en busca de desviaciones | informe (+ arreglos opcionales de bajo riesgo) |
+
+> El motor de hallazgos de `review-change` es el `review-implementation`
+> interno (`user-invocable: false`) — el pase de dos fases encontrar →
+> clasificar que compone, y que reutilizan `audit-pr` / `product-audit`. No es
+> una entrada de menú; ver
+> [Pasos internos](#pasos-internos-ocultos-del-menú-compuestos-por-ti).
+
+## Decidir
+
+| Skill | Rol | Entrega a |
+|---|---|---|
+| `triage-issue` | Clasifica fix-now / promote / postpone / wontfix; verifica disparadores contra el código real; acepta varios issues en un solo lote | `plan-fix`, `plan-feature`, o un comentario fechado |
+
+## Documentar
+
+| Skill | Rol | Entrega a |
+|---|---|---|
+| `generate-docs` | Convierte el diff de una unidad en docs de desarrollador en el propio sitio de docs del proyecto: guías how-to incrementales vía un adaptador descubierto (referencia Starlight MDX, fallback en markdown plano), un mapa de conocimiento/llamadas renderizado desde un comando determinista declarado por el proyecto (nunca inferido por el modelo), exportación opcional `--review` de informes de revisión. El frontmatter de procedencia (`generated-by`/`source-unit`) permite que `audit-docs` detecte páginas huérfanas/obsoletas | el commit de cierre de la unidad (las páginas viajan en el PR de la unidad); `audit-docs` para desviaciones |
+
+## Autopiloto — el flujo completo, de extremo a extremo
+
+| Skill | Rol | Entrega a |
+|---|---|---|
+| `ship-roadmap` | **Conductor.** Una entrevista inicial (producto, features, stack, arquitectura, calidad, operaciones, autonomía, presupuesto) → funda el proyecto si hace falta → crea o adopta el roadmap completo → un bucle impulsado por `/loop` lo despliega feature por feature: compone `plan-feature`, `review-change`, `audit-pr` en el mismo turno (mismo nivel), delega cada fase de `execute-phase` a un subagente Sonnet. Por defecto: abre PRs, el humano fusiona; `--fullauto` fusiona bajo pisos de seguridad no negociables. Termina en un informe final | el humano fusiona / lote de `triage-issue` / `product-audit` (siempre una entrega — su effort máximo supera el high del conductor) |
+
+## Sesión
+
+| Skill | Rol | Entrega a |
+|---|---|---|
+| `log-session` | Añade una entrada estructurada a `docs/LOGS.md` — resumen, archivos, decisiones + *por qué*, siguiente paso — para que un lector nuevo (o la siguiente sesión) retome sin releer el git. Manual y rica; `model: sonnet` (barato). Se complementa con hooks gratuitos y opt-in de `template/.claude/` que añaden automáticamente una entrada mecánica al hacer `/clear`/salir y pueden reinyectar la última entrada al iniciar | `/clear` (sesión capturada) o el comando de reanudación en la línea **Next** de la entrada |
+| `workflow-status` | **Sensor de solo lectura para orquestación programática.** Calcula el estado completo del proyecto — cada feature/fix con su cierre transitivo de dependencias (cumplido/no cumplido), la máquina de cinco estados del roadmap, qué se puede iniciar ahora mismo y en qué orden de construcción, PRs abiertos + estado de auditoría, fixes pendientes y hallazgos a la espera de triage — y lo emite como un único sobre-máquina JSON fijo. La pieza que un driver externo llama entre pasos. Nunca edita nada | la siguiente invocación del driver (nunca entrega el control a otra skill por sí mismo) |
+
+## Mantenimiento del repositorio (específico del repositorio agentic-workflow)
+
+| Skill | Rol |
+|---|---|
+| `bump-skill` | Tras editar un SKILL.md: sube `version:`, añade filas a CHANGELOG.md + CHANGELOG.es.md, actualiza las tablas de skills/modelos del README. Solo para este repositorio — su descripción evita que se dispare en otros proyectos |
+
+## Referencia de invocación y argumentos
+
+Las formas de invocación de cada skill orientada al usuario y qué hace cada
+argumento/flag — el espejo legible para humanos del frontmatter
+`argument-hint` de cada skill. Corchetes `[…]` = opcional; `|` separa formas
+alternativas. Una skill invocada sin argumentos usa el valor por defecto
+indicado aquí.
+
+| Skill | Invocación | Argumentos y flags |
+|---|---|---|
+| `audit-docs` | `/audit-docs [--fix]` | Sin args: solo informe, hallazgos ordenados por severidad. `--fix`: además aplica los arreglos de **bajo riesgo** — los docs nunca se reescriben sin ello (o una confirmación explícita del usuario). |
+| `audit-pr` | `/audit-pr [pr-number]` | Por defecto, el PR de la rama actual. Un número apunta a otro PR. |
+| `design-feature` | `/design-feature <idea \| NN-slug> [instruction]` | Una idea en bruto → entrevista desde cero. Un `NN-slug` existente a secas → **modo revisión**: imprime un resumen de lo que hará la feature y pregunta qué añadir/quitar/cambiar. `NN-slug + instrucción` → aplica el cambio directamente, sin preguntas, acotado a la instrucción. Siempre upsert — el único reinicio desde cero es una instrucción explícita de "borrar y rediseñar". |
+| `execute-phase` | `/execute-phase <NN> [P<k>] \| --fix <n> [P<k>] \| [--force]` | `NN` solo → pase único (features `XS/S` solo-SPEC). `NN P<k>` → exactamente una fase de una feature M/L. `--fix <n>` → implementa la unidad de fix `docs/fix/<n>-*`. `--force` → invalida la puerta de dependencias/estado (válvula de escape solo para el usuario; la invalidación se registra en `decisions.md`; el autopiloto nunca la pasa). |
+| `generate-docs` | `/generate-docs [NN-slug \| fix-n \| path/glob] [--review]` | El alcance por defecto es el diff de la rama actual frente a la rama por defecto; un slug/fix/ruta lo acota o redirige. `--review` → además exporta el informe más reciente de `review-change` como una página de docs (opt-in, nunca automático). |
+| `init-workspace` | `/init-workspace [target-dir]` | Por defecto el directorio actual. En un repositorio que ya tiene el andamiaje, cambia automáticamente al **modo actualización** (propone solo los bloques de plantilla nuevos/faltantes; solo aditivo). |
+| `log-session` | `/log-session [note]` | La nota opcional se antepone al Resumen de la entrada. |
+| `plan-feature` | `/plan-feature <NN-slug \| #N> \| --from-issue N \| --scaffold <slug> \| --next` | Un slug o referencia de issue se detecta automáticamente; los flags fuerzan una ruta: `--from-issue N` (issue → mitad de producto acotada), `--scaffold <slug>` (directo al andamiaje de la mitad de ingeniería), `--next` (siguiente entrada del roadmap). Una feature sin diseñar (fila del roadmap por debajo de `defined`) → se detiene y redirige a `/design-feature` — sin flag de bypass. |
+| `plan-fix` | `/plan-fix <issue-number>` | Obligatorio. Redacta `docs/fix/<n>-<topic>/SPEC.md` en una rama de fix y se detiene para revisión. |
+| `product-audit` | `/product-audit [path-or-area]` | Por defecto, el producto entero; una ruta/área acota el barrido. Solo propone — nunca arregla. |
+| `review-change` | `/review-change [path-or-glob] [--adversarial N]` | Por defecto, el cambio actual (diff de la rama frente a la rama por defecto); una ruta amplía/acota. `--adversarial N` → N revisores adversariales independientes, de contexto limpio, solo-diff, en paralelo, hallazgos fusionados y deduplicados (opt-in; auto-recomendado para cambios `L`/sensibles). |
+| `ship-roadmap` | `/ship-roadmap [--fullauto]` · `/ship-roadmap --continue [--fullauto]` | Por defecto: abre PRs, el humano fusiona. `--fullauto` → fusiona PRs MERGE-READY bajo los pisos de seguridad no negociables. `--continue` → reanuda una ejecución existente por una etapa (el bucle del driver externo reinvoca esto). |
+| `triage-issue` | `/triage-issue <n> [n…]` | Uno o varios números de issue — las ejecuciones en lote producen veredictos independientes más una tabla resumen. |
+| `workflow-status` | `/workflow-status [--json-only] [--last-envelope <json\|path>]` | Por defecto: resumen humano + el sobre-máquina. `--json-only` → solo el sobre (modo driver). `--last-envelope` → el sobre persistido del driver como **pista** de recuperación ante caídas (comparado contra el estado recalculado; nunca autoritativo). ¿Tu agente no pasa argumentos? Pega el JSON en el mensaje — se lee el último bloque json entre comillas de la *solicitud* como la pista. |
+
+## Compañeras integradas (Claude Code)
+
+`/code-review` (corrección + simplificación), `/security-review` (pase de
+seguridad), `/verify` (ejecutar la app, confirmar comportamiento) —
+compuestas por `review-change` cuando aplican al cambio.
+
+## Guardarraíles de dominio (por proyecto — no incluidas)
+
+Las skills de guardarraíl de stack/dominio se cargan automáticamente durante
+la ejecución pero son **específicas del proyecto**, así que viven en cada
+repositorio destino en lugar de aquí — p. ej. una skill de patrón de
+arquitectura, una skill de reglas de dominio, y skills de stack (framework,
+ORM, runtime, plataforma). Ver `RECOMMENDED_SKILLS.md`.
+
+## Cómo se combinan
+
+```
+IDEA / undesigned SPEC ─▶ design-feature (product half + capability closure)
+                          → `## Design status: designed` ─┐
+                   ┌──────────────── plan-feature (router, engineering-planning only) ─┐
+DESIGNED slug/SPEC ┤  --scaffold → plan-feature-scaffold (engineering half)            │
+ISSUE(feature) ────┤  #N / --from-issue → plan-feature-from-issue                      ├─▶ execute-phase ─▶ open PR (`done`) ─▶ review-change ─▶ audit-pr ─▶ merge
+ROADMAP --next ────┘  registers the roadmap entry, prints the next step                │
+                       (undesigned input → STOP, redirect to /design-feature, no bypass)
+
+ISSUE(any) ─▶ triage-issue ─┬─ fix-now ─▶ plan-fix ─▶ execute-phase --fix ─▶ open PR (`done`) ─▶ review-change ─▶ audit-pr ─▶ merge
+                            ├─ promote ─▶ plan-feature (router → from-issue) ─▶ (feature chain above)
+                            ├─ postpone ─▶ dated comment, leave open
+                            └─ wontfix ─▶ propose close
+
+review-change ── runs the applicable reviews + classifies a change (Stage 4, mandatory);
+                 composes review-implementation + the platform's companion skills;
+                 fix-now ─▶ plan-fix · every non-fix-now (postpone/ignore/tradeoff) ─▶ triage-issue
+audit-pr ─────── PR-level merge gate (merge-ready or blockers)
+product-audit ── periodic product-wide sweep → proposes issues + roadmap changes
+audit-docs ───── audits docs ↔ roadmap ↔ code ↔ fix index, anytime
+
+ship-roadmap ─── AUTOPILOT around the whole feature chain: interview → founding →
+                 roadmap → /loop { plan-feature → execute-phase (sonnet subagents)
+                 → review-change → PR → audit-pr → merge } → final report;
+                 human at the merges (default) and at product-audit (always)
+```
+
+## Reglas de diseño que sigue cada skill
+
+1. **Descubrir primero.** Leer la guía del agente, el mapa de documentación,
+   la arquitectura, el roadmap, y los docs de dominio/estilo relevantes antes
+   de actuar. Adaptarse al proyecto.
+2. **Respetar arquitectura y estilo.** Reglas de capas, reglas de
+   dominio/i18n/SEO/a11y, límites de runtime/plataforma, convenciones de
+   nombres — todo respetado, nunca eludido.
+3. **Planificar antes de programar; una fase a la vez; un PR por unidad
+   contra la rama por defecto; nunca `main`, nunca apilado.**
+4. **Evidencia sobre reflejo.** Verificar disparadores, citar rutas/recuentos.
+5. **Rastrear, no implementar sobre la marcha, el trabajo diferido.**
+   Mantener los issues y los docs coherentes e informados.
+6. **Puerta antes del commit.** Chequeo de tipos + tests + build en verde.
+7. **Disciplina de idioma en los docs.** Artefactos en el idioma de docs del
+   proyecto (este repositorio: inglés), sin importar el idioma de la
+   solicitud.
+
+## Anatomía de una skill
+
+Cada skill es una carpeta bajo `.claude/skills/<name>/` con un `SKILL.md`:
+
+```
+---
+name: <kebab-case-name>
+description: >
+  One paragraph with concrete trigger phrases so the model knows when to load it.
+---
+
+# Title
+## When to use
+## Step 0 — Discover the project (always first)
+## Process
+## Guardrails
+## Relationship to other skills
+## Done when
+```

--- a/docs/workflow/SKILLS.md
+++ b/docs/workflow/SKILLS.md
@@ -1,5 +1,7 @@
 # Skill system reference
 
+> 🇪🇸 [Versión en español](SKILLS.es.md)
+
 The skills that make up the agentic workflow, grouped by role.
 
 **14 user-facing skills** (one menu entry each) + **14 internal** steps composed

--- a/packages/agentic-workflow-schema/README.es.md
+++ b/packages/agentic-workflow-schema/README.es.md
@@ -1,0 +1,200 @@
+# @gtrabanco/agentic-workflow-schema
+
+> 🇬🇧 [English version](README.md)
+
+Tipos, JSON Schema, y parser/validador para el **sobre-máquina** de
+[agentic-workflow](https://github.com/gtrabanco/agentic-workflow) — el
+bloque JSON fijo con el que termina un turno de agente conducido (emitido
+siempre por `workflow-status`, y por cualquier otra skill cuando el driver
+inyecta el fragmento canónico de system-prompt — ver el protocolo de driver
+abajo), para que orquestadores externos puedan enrutar el flujo de trabajo
+programáticamente (qué comando sigue, en qué nivel de modelo).
+
+Cero dependencias en tiempo de ejecución. Fuente de verdad del contrato:
+[`skills/orchestration-envelope/SKILL.md`](https://github.com/gtrabanco/agentic-workflow/blob/main/skills/orchestration-envelope/SKILL.md);
+protocolo de driver:
+[`docs/workflow/ORCHESTRATION.md`](https://github.com/gtrabanco/agentic-workflow/blob/main/docs/workflow/ORCHESTRATION.md).
+
+## Instalación
+
+```sh
+npm install @gtrabanco/agentic-workflow-schema
+```
+
+## Uso
+
+```ts
+import {
+  parseEnvelope,
+  isTerminal,
+  isRunHalt,
+} from "@gtrabanco/agentic-workflow-schema";
+
+const output = await runAgentHeadless("Follow the installed SKILL.md for: /workflow-status --json-only");
+
+const result = parseEnvelope(output); // extracts the LAST fenced ```json block
+if (!result.ok) throw new Error(result.errors.join("; "));
+
+const env = result.envelope; // fully typed
+if (isRunHalt(env)) stopEverythingAndPage(env.blockers);
+else if (isTerminal(env.state)) askHuman(env);
+else invokeNext(env.next.recommended, env.next.tier); // "strong" | "cheap"
+```
+
+El contrato de parseo es exactamente lo que prometen las skills: **el
+último bloque
+```` ```json ````…```` ``` ```` entre comillas del mensaje final es el
+sobre**, uno por turno, todas las claves de nivel superior siempre
+presentes.
+
+También exportados: `extractLastJsonBlock(text)`, `validateEnvelope(value)`,
+`ENVELOPE_STATES` (el enum de 11 estados), `TERMINAL_STATES`, y cada tipo
+de campo. También se distribuye un **JSON Schema** agnóstico de lenguaje —
+funciona con el mínimo de `engines.node` (>=18):
+
+```ts
+import { createRequire } from "node:module";
+const schema = createRequire(import.meta.url)("@gtrabanco/agentic-workflow-schema/envelope.schema.json");
+```
+
+En Node 20.10+/22, la forma más nueva de import-attributes también
+funciona:
+
+```ts
+import schema from "@gtrabanco/agentic-workflow-schema/envelope.schema.json" with { type: "json" };
+```
+
+## El sobre, campo por campo
+
+Cada clave de nivel superior está **siempre presente** (`required` en el
+JSON Schema) — una skill que no tiene nada que reportar para una clave usa
+`null` / `[]` / `0`, nunca la omite. **Cerrado** = el enum exacto de abajo
+es exhaustivo (el validador rechaza cualquier otra cosa); **abierto** =
+forma libre, cualquier valor del tipo indicado.
+
+| Campo | Tipo | Valores | Significado |
+|---|---|---|---|
+| `skill` | string | abierto (no vacío) | Qué skill produjo este sobre. |
+| `state` | enum | **cerrado** — los 11 estados de abajo | La clave de enrutamiento. Todo lo que decide un orquestador empieza aquí. |
+| `summary` | string | abierto | Una frase en texto plano: qué pasó este turno. |
+| `unit.type` | enum | **cerrado** — `feature` · `fix` · `docs` · `none` | Qué tipo de unidad trabajó el turno. |
+| `unit.id` | string\|null | abierto | El identificador de la unidad (`NN-slug` para features, `n-topic` para fixes). |
+| `unit.issue` | integer\|null | abierto | El número del issue de rastreo, cuando la unidad nace de un issue. |
+| `unit.branch` | string\|null | abierto | La rama de trabajo. |
+| `phase.current` | string\|null | abierto (por convención `P1`, `P2`, …) | Fase recién trabajada, para features en fases (M/L). |
+| `phase.total` / `phase.completed` | integer\|null | abierto | Recuentos de fase; `null` para unidades de pase único. |
+| `pr.number` / `pr.url` / `pr.head_sha` | int/str\|null | abierto | El PR de la unidad, una vez que existe. |
+| `pr.state` | enum | **cerrado** — `open` · `merged` · `none` | El estado de merge vive en la forja, no en el roadmap. |
+| `pr.merge_ready` | boolean\|null | abierto | `true` solo después de un veredicto MERGE-READY de `audit-pr` sobre la cabeza actual. |
+| `pr.ci` | enum | **cerrado** — `green` · `red` · `pending` · `none` · `null` | `none` = el proyecto no tiene CI; `null` = no comprobado este turno. |
+| `gates.verification` | enum | **cerrado** — `green` · `red` · `not-run` · `null` | La propia puerta del proyecto (chequeo de tipos + tests + build) tal como se ejecutó por última vez. |
+| `gates.review_pending` / `gates.audit_pending` | boolean\|null | abierto | Si la revisión obligatoria / auditoría de merge todavía tiene que suceder. |
+| `findings.fix_now[]` | array de objetos | items: `ref` (abierto), `title` (abierto), `file` (abierto, nullable) | Hallazgos que deben incorporarse a la rama ACTUAL antes de que avance. |
+| `findings.issues_filed[]` | array de enteros | abierto | Números de issue creados/actualizados este turno. |
+| `findings.untriaged` | integer ≥ 0 | abierto | Hallazgos todavía sin destino — las skills cuyo contrato enruta todo deben reportar `0`. |
+| `findings.decisions_recorded` | integer ≥ 0 | abierto | Decisiones escritas en registros clase `decisions.md` este turno. |
+| `blockers[].kind` | enum | **cerrado** — `dependency` · `issue` · `gate` · `merge-conflict` · `substrate` · `input` | Por qué la unidad (o la ejecución) no puede avanzar. |
+| `blockers[].scope` | enum | **cerrado** — `unit` · `run` | `run` significa parar-el-mundo: nada más avanza tampoco. |
+| `blockers[].id` / `blockers[].detail` | string | abierto | Qué exactamente (un slug, `#N`, un nombre de check) + una línea de contexto. |
+| `dependencies.unmet[]` / `dependencies.build_order[]` | arrays de string | abierto | Referencias de roadmap/issue no cumplidas, y el orden más-profundo-primero para construirlas. |
+| `recommendations.product_audit` | boolean | abierto | `true` cuando una desviación recurrente sugiere que las suposiciones fundacionales están obsoletas. |
+| `recommendations.reason` | string\|null | abierto | Por qué (requerido en la práctica cuando el flag es `true`). |
+| `needs_input` | object\|null | `question` (abierto) + `options[]` (abierto) | No-nulo solo en `state: NEEDS_INPUT` — la decisión humana a mostrar, con opciones concretas. Nada se adivinó. |
+| `next.recommended` | string | abierto (una invocación de skill) | El único mejor comando siguiente. |
+| `next.alternatives[]` | array de string | abierto | Las otras elecciones defendibles. |
+| `next.tier` | enum | **cerrado** — `strong` · `cheap` | Qué clase de modelo merece el siguiente paso — juicio vs. mecánico. |
+| `detail` | any | abierto (específico de la skill) | Carga útil por skill — p. ej. `workflow-status` lleva aquí el árbol completo del proyecto (`features`, `fixes`, `startable_now`, `blocked_units`, `crash_recovery`, …). |
+
+### La tabla de enrutamiento de `state` (cerrada — exactamente estos 11)
+
+| `state` | Significado | Acción del orquestador |
+|---|---|---|
+| `OK` | La skill terminó su trabajo | Invocar `next.recommended` en `next.tier` |
+| `CONTINUE` | Misma unidad, más del mismo trabajo | Reinvocar `next.recommended` (los checkpoints consultivos también aterrizan aquí — la alternativa está listada) |
+| `READY_FOR_REVIEW` | Unidad terminada; revisión obligatoria a continuación | `/review-change` en un modelo fuerte, contexto nuevo |
+| `READY_FOR_AUDIT` | Revisión limpia | `/audit-pr` (fuerte) |
+| `MERGE_READY` | Auditoría aprobada sobre el SHA de cabeza actual | El humano fusiona — o lo hace tu política de auto-merge escrita |
+| `MERGED` | Un auto-merge autorizado se ejecutó este turno | Siguiente unidad: consultar `workflow-status` |
+| `NEEDS_FIXES` | `findings.fix_now` no está vacío | Incorporar en la rama (commit Y push), luego reejecutar la puerta que los emitió |
+| `BLOCKED` | Dependencia no cumplida / causa externa | Seguir `dependencies.build_order`, o resolver `blockers[]` |
+| `NEEDS_INPUT` | Un humano debe decidir | Mostrar `needs_input.question` + `options`; reanudar con la respuesta |
+| `FAILED` | Reintentos agotados | Detener esta unidad; un humano la revisa |
+| `HALT` | Descubrimiento de parar-el-mundo (`blockers[].scope: "run"`) | Detener toda la ejecución; nada avanza hasta que un humano lo despeje |
+
+`isTerminal(state)` cubre `NEEDS_INPUT` / `FAILED` / `HALT` (+
+`MERGE_READY` con puerta humana); `isRunHalt(envelope)` es la comprobación
+de `HALT` / bloqueador con alcance de ejecución.
+
+## Orquestar con este esquema
+
+Dos patrones, ambos consumiendo el mismo sobre. En ambos, **inyecta el
+fragmento canónico de system-prompt** en cada invocación headless (las
+skills no emiten el sobre por sí solas — `workflow-status` es la única
+excepción):
+
+```text
+Every turn you produce MUST end with exactly one fenced ```json block matching
+the orchestration envelope schema (all top-level keys present; values only
+from verified command output). Emit nothing after it.
+```
+
+…y ejecuta el **bucle de reparación** ante un fallo de parseo — un
+reintento, luego falla el paso:
+
+```ts
+async function turn(prompt: string) {
+  let out = await invokeAgent(prompt, { system: SNIPPET });
+  let r = parseEnvelope(out);
+  if (!r.ok) {
+    out = await invokeAgent("Emit only the machine envelope for the turn above.", { resume: true });
+    r = parseEnvelope(out);
+    if (!r.ok) throw new Error(`step failed: no valid envelope (${r.errors.join("; ")})`);
+  }
+  return r.envelope;
+}
+```
+
+**Patrón 1 — bucle de driver fijo** (empieza aquí): consulta el sensor,
+enruta por `state`, repite. Esqueleto completo en
+[`docs/workflow/ORCHESTRATION.md`](https://github.com/gtrabanco/agentic-workflow/blob/main/docs/workflow/ORCHESTRATION.md),
+incluido el protocolo de reinicio de recuperación ante caídas (pista
+`--last-envelope` + diario de sobres solo-anexar).
+
+**Patrón 2 — flujos de trabajo dinámicos** (el patrón conductor): un
+contexto conductor de larga duración *escribe y monitoriza* el plan de
+trabajo; cada trabajador se ejecuta en un **contexto limpio** y solo su
+sobre fluye de vuelta hacia arriba — el conductor nunca ingiere
+transcripciones en bruto, que es lo que le permite mantenerse de larga
+duración sin degradarse. El sobre es precisamente el "resultado
+estructurado" que necesita este patrón:
+
+```ts
+// Conductor: fan out independent units (workflow-status said they're startable
+// in parallel and the project declares `worktrees`), read back only envelopes.
+const status = await turn("Follow the installed SKILL.md for: /workflow-status --json-only");
+const units = status.detail.startable_now as string[];
+
+const results = await Promise.all(
+  units.map((u) => turn(`Follow the installed SKILL.md for: /execute-phase ${u}`))
+);
+
+for (const env of results) {
+  if (isRunHalt(env)) throw new Error(`HALT: ${JSON.stringify(env.blockers)}`);
+  if (env.state === "NEEDS_FIXES")
+    await turn(`Fold the fix-now findings on ${env.unit.branch}: ${JSON.stringify(env.findings.fix_now)}`);
+}
+// The conductor's own context grew by a few KB of envelopes — not by N transcripts.
+```
+
+Piso de seguridad para cualquier driver, bucle fijo o dinámico: nunca
+saltarse una puerta `review_pending`/`audit_pending`, nunca fusionar salvo
+con un `MERGE_READY` fresco ligado al SHA de cabeza actual, y tratar
+`HALT` como terminal hasta que un humano lo despeje.
+
+## Versionado
+
+El semver de este paquete sigue al **contrato del sobre**, no al
+repositorio: cambio disruptivo del esquema (clave eliminada/renombrada,
+estado eliminado) → major; aditivo (clave opcional nueva, estado nuevo) →
+minor; arreglos/docs → patch. Cuando cambia la skill
+`orchestration-envelope`, este paquete cambia en el mismo PR.

--- a/packages/agentic-workflow-schema/README.md
+++ b/packages/agentic-workflow-schema/README.md
@@ -1,5 +1,7 @@
 # @gtrabanco/agentic-workflow-schema
 
+> 🇪🇸 [Versión en español](README.es.md)
+
 Types, JSON Schema, and parser/validator for the
 [agentic-workflow](https://github.com/gtrabanco/agentic-workflow) **machine
 envelope** — the fixed JSON block a driven agent turn ends with (emitted by

--- a/packages/agentic-workflow-schema/package.json
+++ b/packages/agentic-workflow-schema/package.json
@@ -32,6 +32,7 @@
     "dist",
     "envelope.schema.json",
     "README.md",
+    "README.es.md",
     "LICENSE"
   ],
   "engines": {


### PR DESCRIPTION
## What

Extends the repo's bilingual "front door" (previously only `README` and
`CHANGELOG` had EN/ES siblings) to **every human-readable documentation
file**:

- Adds Spanish `.es.md` siblings for all 11 `docs/workflow/*.md` tutorial
  and reference docs, and for `packages/agentic-workflow-schema/README.md`
  (12 new files total), each with reciprocal `> 🇪🇸 [Versión en
  español](...)` / `> 🇬🇧 [English version](...)` language-switcher links.
- Wires `README.es.md` into the schema package's `files` array so it ships
  on the next npm publish.
- Records the go-forward convention in `CLAUDE.md`: human-readable docs
  carry EN + ES siblings kept in sync **on next touch** (no automated
  bookkeeping), while `SKILL.md`, SPECs, commits, PRs, and machine config
  stay English-only.
- **Folded in (owner decision, see SPEC "Decisions made during
  drafting"):** revises the model-routing recommendation in `README.md` +
  `README.es.md` — `GLM-5.2` left the basic NaN.builders plan and is
  repositioned as the **€200-plan** primary; the basic-plan default is now
  a quota-aware, 2–3-deep preference ladder per task (merge gates,
  planning/routing/triage, execution/mechanical, cheap, and the
  `execute-phase` fold cycle), plus a 5-model pros/cons table. No new
  benchmark claims — grounded in the NaN.builders catalog's published caps.

## Why

Spanish-speaking readers learning the workflow, or authoring a driver
against the schema package, had no `.es.md` counterpart for any of the
deeper docs — only the repo's front door was bilingual. This is scope
completion, not a new pattern. The model-routing revision rides the same
PR at the owner's explicit direction (2026-07-12) since `GLM-5.2`'s
plan-availability change made the existing recommendation stale.

## Evidence

- `npx skills add . --list` — all skills discovered, exit 0.
- `npm test` in `packages/agentic-workflow-schema` — 13/13 pass.
- `npm pack --dry-run` — confirms `README.es.md` (11.9kB) ships in the
  package tarball.
- Full link-resolution sweep across all 12 new `.es.md` files plus
  `README.md`/`README.es.md`/`CLAUDE.md` — 0 broken links.
- Grep-checked every phase for stack/real-project references — none
  introduced.
- `README.md` and `README.es.md`'s revised model-routing sections verified
  to match 1:1 (model names, sizes, context, quota figures, ladder
  ordering — only the localized unit labels differ).
- `MIGRATION.es.md`'s two same-page anchor links re-slugged and verified
  programmatically against GitHub's heading-slug algorithm.

## Out of scope (per SPEC)

- `docs/workflow/model-routing.yml` — machine config, English-only.
- `skills/*/SKILL.md` — agent-facing contract, English-only.
- `docs/features/**`, `docs/fix/**`, `.github/**` — process artifacts, not
  human tutorial prose.

Closes #37
