### PR TITLE
fix(docs): remove stale 2026-07-05 merge-order note from ROADMAP.md

### DIFF
--- a/docs/features/ROADMAP.md
+++ b/docs/features/ROADMAP.md
@@ -26,18 +26,6 @@ every row must have a folder (or be explicitly marked "scheduled").
 | 16 | `nan-model-guidance` | done · [#56](https://github.com/gtrabanco/agentic-workflow/pull/56) | — (docs-only touch on 04 10 12, all merged) | Opportunistic (not backlog-chained, S): corrects the README's NaN.builders/OpenAI-compatible provider guidance against that provider's own API reference — the prior "1:1 uniform effort dial" claim was false. Adds a per-model reasoning-control matrix + `effort:` mapping, demotes the model with unvalidated/XML-format tool calling out of the agentic-execution ladder, adds a GLM-5.2 catalog-verification caveat and per-key rate/concurrency limits. `orchestration-envelope` (1.2.0, minor) + `ORCHESTRATION.md` gain a structured-outputs shortcut for forcing the driver-injected envelope where the provider supports strict JSON schema, repair loop as fallback. `ship-roadmap` (2.2.1, patch) gains a Portability concurrency guardrail. `GOLDEN_FIXTURE.md` gains a tool-calling smoke test as a model precondition for the executor path |
 | 17 | `finding-severity-routing` | done · [#57](https://github.com/gtrabanco/agentic-workflow/pull/57) | — (soft: 37 docs the manual ladder) | Issue [#49](https://github.com/gtrabanco/agentic-workflow/issues/49) (M): surface per-finding severity so the fold cycle can route the fixing model per finding. `review-change`/`audit-pr` compute a `Sev` per finding but persist nothing; this adds a per-unit **fix-now fold ledger** (`review-findings.md`, schema `\| id \| file:line \| axis \| severity \| class \| route \| folded \|`) the writer skills append to (fix-now only; non-fix-now stays with `triage-issue`), `execute-phase`'s fold cycle ticks (`folded: no→yes`), and `workflow-status` reads (read-only) to emit `findings.fix_now[]` items carrying `severity` + a derived `suggested_tier` (severity `high` OR subtle axis → `strong`; else `cheap`, reusing `next.tier`'s vocabulary). `next.tier` unchanged. Schema package mirrored (item shape + version bump) same PR; `template/` mirrors the ledger convention. Resolves #49's two scope questions (D1 new ledger; D2 verbatim severity + derived tier) |
 
-> **Merge order & shared-file coupling (2026-07-05).** Features 01–03 are
-> functionally independent (no `Depends on:`), but their PRs edit overlapping
-> files — `skills/init-workspace/SKILL.md` (01: Docs site round → 1.7.0; 02:
-> Performance tooling round → 1.8.0), `skills/execute-phase/SKILL.md` (01 →
-> 1.13.0; 03 → 1.13.1), `template/CLAUDE.md`, and both CHANGELOGs. **Merge in
-> PR order: [#8](https://github.com/gtrabanco/agentic-workflow/pull/8) →
-> [#9](https://github.com/gtrabanco/agentic-workflow/pull/9) →
-> [#10](https://github.com/gtrabanco/agentic-workflow/pull/10)**, resolving
-> conflicts by **keeping both sides' additions** (both interview rounds, both
-> changelog rows, the higher version number). A "take theirs/ours" resolution
-> silently drops one feature's content while other skills still reference it.
-
 ## Status legend
 
 The pipeline's single ground-truth state machine — every sensor and executor

--- a/docs/fix/101-stale-roadmap-merge-order-note/SPEC.md
+++ b/docs/fix/101-stale-roadmap-merge-order-note/SPEC.md
@@ -123,7 +123,7 @@ history at any time. No data-side cleanup (documentation-only).
 
 ## Status
 
-`in-progress`
+`done`
 
 ## Cross-issue notes
 

--- a/docs/fix/101-stale-roadmap-merge-order-note/SPEC.md
+++ b/docs/fix/101-stale-roadmap-merge-order-note/SPEC.md
@@ -1,0 +1,151 @@
+# fix/101-stale-roadmap-merge-order-note
+
+## Goal
+
+Remove the dead "Merge order & shared-file coupling (2026-07-05)" note from
+`docs/features/ROADMAP.md` — a one-time sequencing instruction for PRs #8,
+#9, #10 (all merged long ago) that now has zero forward-looking value and is
+read on every `workflow-status`/`design-feature` invocation.
+
+## Issue
+
+`#101` — GitHub issue. The PR closes it via `Closes #101` in the body.
+
+## Branch
+
+`fix/101-stale-roadmap-merge-order-note`
+
+## Depends on
+
+— (independent)
+
+## Root cause
+
+The note was added as a one-time sequencing instruction for the initial
+three-feature merge window (2026-07-05, features 01-03 sharing overlapping
+files). It was never cleaned up once the window closed — no mechanism
+enforces removing a one-time note after its triggering PRs merge.
+
+## Detected in
+
+`/product-audit` run on 2026-07-19 (Roadmap coherence dimension). Confirmed
+via `gh pr view 8/9/10 --json state,mergedAt` — all three `MERGED` on
+2026-07-05, closing the file-coupling window the note existed to protect.
+
+## Scope
+
+### In scope
+
+- Remove the "Merge order & shared-file coupling (2026-07-05)" note
+  (`docs/features/ROADMAP.md` lines 29-39) in its entirety.
+
+### Out of scope
+
+- `docs/fix/README.md`'s 21 stale merged-PR rows — tracked separately in
+  `docs/fix/100-stale-fix-index-rows/`.
+- Any other content in `docs/features/ROADMAP.md` (the Features table, the
+  status legend, etc.) — untouched.
+
+## Acceptance
+
+- [x] `docs/features/ROADMAP.md` no longer contains the
+      "Merge order & shared-file coupling (2026-07-05)" note.
+- [x] The Features table (rows 01-17) and Status legend are byte-for-byte
+      unchanged aside from the removed note.
+- [x] The note remains recoverable from git history (no `--amend`/force-push
+      involved in this fix).
+
+## Phases
+
+Execution ledger — `execute-phase --fix` runs **one phase per invocation**
+and ticks tasks here.
+
+### Phase-lint (authoritative copy — keep in sync with `docs/features/_TEMPLATE/SPEC.md` `### Phases`)
+
+Every implementation phase below must pass all 8 boxes before it is emitted
+(planner skills) or executed (`execute-phase` pre-flight). Fail-closed: any
+unticked box blocks emission/execution until the phase is re-cut or split.
+
+- [ ] Title names ONE deliverable — FAIL if it joins nouns with `+`, `,`,
+      `&`, `and`/`y`, or `/`.
+- [ ] One declared layer — each phase declares exactly one of the fixed enum
+      `schema/db | domain | api | ui | config/infra | docs | hardening |
+      close-out`; FAIL if any task's target file belongs to another. Tests
+      for the phase's own layer belong to the phase; a test-only phase
+      declares `hardening`.
+- [ ] ≤ 8 tasks (close-out phase: ≤ 10, only the literal close-out chain).
+- [ ] One checkbox = one deliverable — FAIL if a task contains a `→` chain
+      of implementation steps, enumerates > 3 cases/scenarios, or creates
+      > 1 file of distinct concerns.
+- [ ] Zero decision words — FAIL on `Decide`, `choose`, `OR` between
+      alternatives, `If … then <change scope>`.
+- [ ] No conditional scope mutation — a task may not move work between
+      phases at runtime.
+- [ ] No external/manual gates inside implementation phases —
+      human/out-of-repo verifications live in the hardening/close-out phase,
+      marked `manual`.
+- [ ] Machine-checkable done-when — every phase ends with one verifiable
+      invariant (a command + expected outcome).
+
+### P1 — Remove the stale merge-order note
+
+Layer: `docs`. Done-when:
+`grep -c 'Merge order & shared-file coupling' docs/features/ROADMAP.md` →
+returns `0`.
+
+- [x] Delete the "Merge order & shared-file coupling (2026-07-05)" blockquote
+      from `docs/features/ROADMAP.md` (Features table and Status legend
+      untouched) — evidence: `grep -c 'Merge order & shared-file coupling'
+      docs/features/ROADMAP.md` → `0`
+
+### P2 — Hardening & PR
+
+- [ ] Re-run the project's full verification gate (commands + exit codes pasted)
+- [ ] Pending-docs check: `git status --porcelain -- docs/` → empty
+- [ ] Set the fix-index row status to `done` and commit the flip
+- [ ] `git push`
+- [ ] Open the PR (`gh pr create --body-file <path>` — body written as a
+      Markdown file, real backticks, never inline `--body`/heredoc) and
+      PRINT THE PR URL in the chat; the body includes `Closes #101`
+- [ ] Update the fix-index row to `done · [#<pr>](<pr-url>)`
+- [ ] Commit `docs: link PR #101` and push
+
+## Testing
+
+Docs-only change; no test layer applies. Verification is the `grep`
+done-when above plus a visual diff review confirming only the note block was
+removed.
+
+## Rollback
+
+Single `git revert` of the PR commit — the note is recoverable from git
+history at any time. No data-side cleanup (documentation-only).
+
+## Status
+
+`in-progress`
+
+## Cross-issue notes
+
+None found blocking, blocked-by, overlapping, or absorbable via
+`gh issue list --state open` / `gh pr list --state open` at drafting time,
+other than sibling fix #100 (different file, different defect class — kept
+separate per the shared-root-cause checklist).
+
+## Effort
+
+XS (1 commit, ≤ 1h) — mechanical deletion of one dead blockquote.
+
+## Decisions made during drafting
+
+- Chose **delete** over **relocate** (the issue's acceptance criteria leaves
+  this to the maintainer). The note is a one-time, closed-window instruction
+  with zero remaining audience; git history and `git log -p` on this file
+  already preserve it verbatim, so relocating it into `CHANGELOG.md` or
+  `docs/workflow/MIGRATION.md` would only duplicate that history without
+  adding value. If the user disagrees, this is trivially reverted /
+  redirected before merge.
+- Did not merge with #100 into one unit: different files
+  (`docs/features/ROADMAP.md` vs `docs/fix/README.md`) and different defect
+  classes (a stale one-time merge-order note vs. stale merged-PR rows) —
+  fails the shared-root-cause checklist's first box.

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -15,6 +15,7 @@ this table — history lives in git log + closed issues.
 | Folder | Topic | Status | Depends on | Issue |
 | ------ | ----- | ------ | ---------- | ----- |
 | `100-stale-fix-index-rows` | Drop 21 stale rows from this table pointing to already-merged PRs | done · [#102](https://github.com/gtrabanco/agentic-workflow/pull/102) | — | [#100](https://github.com/gtrabanco/agentic-workflow/issues/100) |
+| `101-stale-roadmap-merge-order-note` | Remove the dead 2026-07-05 merge-order note for PRs #8/#9/#10 (all merged) from `docs/features/ROADMAP.md` | in-progress | — | [#101](https://github.com/gtrabanco/agentic-workflow/issues/101) |
 
 ---
 

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -15,7 +15,7 @@ this table — history lives in git log + closed issues.
 | Folder | Topic | Status | Depends on | Issue |
 | ------ | ----- | ------ | ---------- | ----- |
 | `100-stale-fix-index-rows` | Drop 21 stale rows from this table pointing to already-merged PRs | done · [#102](https://github.com/gtrabanco/agentic-workflow/pull/102) | — | [#100](https://github.com/gtrabanco/agentic-workflow/issues/100) |
-| `101-stale-roadmap-merge-order-note` | Remove the dead 2026-07-05 merge-order note for PRs #8/#9/#10 (all merged) from `docs/features/ROADMAP.md` | in-progress | — | [#101](https://github.com/gtrabanco/agentic-workflow/issues/101) |
+| `101-stale-roadmap-merge-order-note` | Remove the dead 2026-07-05 merge-order note for PRs #8/#9/#10 (all merged) from `docs/features/ROADMAP.md` | done | — | [#101](https://github.com/gtrabanco/agentic-workflow/issues/101) |
 
 ---
 

--- a/docs/fix/README.md
+++ b/docs/fix/README.md
@@ -15,7 +15,7 @@ this table — history lives in git log + closed issues.
 | Folder | Topic | Status | Depends on | Issue |
 | ------ | ----- | ------ | ---------- | ----- |
 | `100-stale-fix-index-rows` | Drop 21 stale rows from this table pointing to already-merged PRs | done · [#102](https://github.com/gtrabanco/agentic-workflow/pull/102) | — | [#100](https://github.com/gtrabanco/agentic-workflow/issues/100) |
-| `101-stale-roadmap-merge-order-note` | Remove the dead 2026-07-05 merge-order note for PRs #8/#9/#10 (all merged) from `docs/features/ROADMAP.md` | done | — | [#101](https://github.com/gtrabanco/agentic-workflow/issues/101) |
+| `101-stale-roadmap-merge-order-note` | Remove the dead 2026-07-05 merge-order note for PRs #8/#9/#10 (all merged) from `docs/features/ROADMAP.md` | done · [#103](https://github.com/gtrabanco/agentic-workflow/pull/103) | — | [#101](https://github.com/gtrabanco/agentic-workflow/issues/101) |
 
 ---
 


### PR DESCRIPTION
## What

Removes the dead "Merge order & shared-file coupling (2026-07-05)" note from
`docs/features/ROADMAP.md`.

## Why

The note was a one-time sequencing instruction for PRs #8, #9, #10 (features
01-03), which shared overlapping files during their initial merge window.
All three merged on 2026-07-05, closing that window. The note has had zero
forward-looking value since, yet was still being read on every
`workflow-status`/`design-feature` invocation.

## Evidence

- `gh pr view 8/9/10 --json state,mergedAt` — all three confirmed `MERGED`
  on 2026-07-05.

## Decision

Chose to **delete** the note rather than relocate it to `CHANGELOG.md` or
`docs/workflow/MIGRATION.md` (the issue left this to the maintainer's call):
git history already preserves it verbatim, so relocating would only
duplicate that history without adding value.

## SPEC

`docs/fix/101-stale-roadmap-merge-order-note/SPEC.md`

Closes #101
