### PR TITLE
fix(distribution): install runtime contracts

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -29,10 +29,12 @@
     "./skills/log-session",
     "./skills/loop-review-fold",
     "./skills/orchestration-envelope",
+    "./skills/phase-contract",
     "./skills/plan-feature",
     "./skills/plan-feature-from-issue",
     "./skills/plan-feature-scaffold",
     "./skills/plan-fix",
+    "./skills/planning-preflight",
     "./skills/product-audit",
     "./skills/resolve-repository-state",
     "./skills/review-a11y",
@@ -48,6 +50,7 @@
     "./skills/review-verify",
     "./skills/ship-roadmap",
     "./skills/triage-issue",
+    "./skills/verification-contract",
     "./skills/workflow-status"
   ]
 }

--- a/CHANGELOG.es.md
+++ b/CHANGELOG.es.md
@@ -463,6 +463,9 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 | Skill | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|---|
 | `orchestration-envelope` | 1.5.1 | 2026-08-09 | parche | Sin cambio de comportamiento: comprime emisión, reglas de campos, repair loop, sincronización de paquete, relaciones y NRS preservando esquema y protocolo del driver. |
+| `verification-contract` | 1.0.1 | 2026-08-09 | parche | Registra esta dependencia de ejecución para su distribución y la mantiene fuera del menú invocable por el usuario, de modo que el `skills add` normal instala el contrato consumido por planificadores, ejecutores, revisores y loops. |
+| `planning-preflight` | 1.1.1 | 2026-08-09 | parche | Registra esta dependencia de ejecución para su distribución y la mantiene fuera del menú invocable por el usuario. |
+| `phase-contract` | 1.0.1 | 2026-08-09 | parche | Registra esta dependencia de ejecución para su distribución y la mantiene fuera del menú invocable por el usuario. |
 | `verification-contract` | 1.0.0 | 2026-08-09 | — | Nuevo contrato interno: congela un `ACCEPTANCE.md` compacto por unidad, liga la evidencia de ejecución/review a su blob, define estados de validación y prohíbe debilitar tests o aceptación para fabricar verde. |
 | `orchestration-envelope` | 1.5.0 | 2026-08-09 | menor | El contrato canónico de turno lleva el blob de aceptación congelado y prohíbe crear issues automáticamente para propuestas independientes, habilitando drivers acotados de unidad completa y review/fold sin cambiar el esquema JSON. |
 | `plan-feature-scaffold` | 1.14.0 | 2026-08-09 | menor | Emite el manifiesto de aceptación congelado para cualquier tamaño de feature y entrega por defecto todas las fases restantes a la ejecución solo-con-objetivo. |
@@ -552,6 +555,11 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 ---
 
 ## Registro cronológico (más reciente primero)
+
+- **2026-08-09 — distribuir contratos de ejecución.** La ruta normal de
+  `skills add` ahora instala `phase-contract`, `planning-preflight` y
+  `verification-contract` junto a los entrypoints que los consumen, manteniendo
+  los tres fuera del menú invocable por el usuario.
 
 - **2026-08-09 — loops acotados de entrega (feature 22).** Aceptación
   congelada, ejecución de unidad completa solo-con-objetivo con workers limpios

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -462,6 +462,9 @@ How pinning actually works, verified against the `skills` CLI:
 | Skill | Version | Date | Type | What changed |
 |---|---|---|---|---|
 | `orchestration-envelope` | 1.5.1 | 2026-08-09 | patch | No behavior change: compresses emission, field-rule, repair-loop, package-sync, relationship, and NRS prose while preserving the schema and driver protocol. |
+| `verification-contract` | 1.0.1 | 2026-08-09 | patch | Registers this runtime dependency for distribution and keeps it out of the user-invocable menu, so default `skills add` installs the contract consumed by planners, executors, reviewers, and loops. |
+| `planning-preflight` | 1.1.1 | 2026-08-09 | patch | Registers this runtime dependency for distribution while keeping it out of the user-invocable menu. |
+| `phase-contract` | 1.0.1 | 2026-08-09 | patch | Registers this runtime dependency for distribution while keeping it out of the user-invocable menu. |
 | `verification-contract` | 1.0.0 | 2026-08-09 | — | New internal contract: freezes one compact `ACCEPTANCE.md` per unit, binds execution/review evidence to its blob, defines validation states, and forbids weakening tests or acceptance to manufacture green. |
 | `orchestration-envelope` | 1.5.0 | 2026-08-09 | minor | The canonical turn contract carries the frozen acceptance blob and forbids automatic issue creation for independent proposals, enabling bounded whole-unit and review/fold drivers without changing the JSON schema. |
 | `plan-feature-scaffold` | 1.14.0 | 2026-08-09 | minor | Emits the frozen acceptance manifest for every feature size and hands target-only execution all remaining phases by default. |
@@ -551,6 +554,11 @@ How pinning actually works, verified against the `skills` CLI:
 ---
 
 ## Release log (chronological, newest first)
+
+- **2026-08-09 — distribute runtime contracts.** The default `skills add` path now
+  installs `phase-contract`, `planning-preflight`, and `verification-contract`
+  alongside the entrypoints that consume them, while keeping all three out of
+  the user-invocable menu.
 
 - **2026-08-09 — bounded delivery loops (feature 22).** Frozen acceptance,
   target-only whole-unit execution with fresh phase workers, compatible

--- a/scripts/bounded-delivery-loops.test.mjs
+++ b/scripts/bounded-delivery-loops.test.mjs
@@ -60,7 +60,13 @@ assert.match(verification, /git hash-object/);
 assert.match(verification, /deleting, skipping, narrowing, or loosening a validator/);
 
 const pluginSkills = plugin.skills.map((entry) => entry.replace("./skills/", ""));
-assert.ok(pluginSkills.includes("loop-review-fold"));
+for (const requiredDependency of ["loop-review-fold", "phase-contract", "planning-preflight", "verification-contract"]) {
+  assert.ok(pluginSkills.includes(requiredDependency), `${requiredDependency} must be distributed by plugin.json`);
+}
+for (const distributedDependency of ["phase-contract", "planning-preflight", "verification-contract"]) {
+  assert.doesNotMatch(read(`skills/${distributedDependency}/SKILL.md`), /^metadata:\n  internal: true$/m,
+    `${distributedDependency} must remain discoverable by the skills CLI`);
+}
 assert.deepEqual(pluginSkills, [...pluginSkills].sort(), "plugin skills must stay alphabetical");
 
 console.log("PASS bounded delivery loop contracts");

--- a/skills/phase-contract/SKILL.md
+++ b/skills/phase-contract/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: phase-contract
 user-invocable: false
-version: 1.0.0
+version: 1.0.1
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
-metadata:
-  internal: true
 description: >
   Internal contract: the single owner of the eight phase-lint rules, the fixed
   PASS/BLOCKED result, and the normalized phase fingerprint. Consumed by

--- a/skills/planning-preflight/SKILL.md
+++ b/skills/planning-preflight/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: planning-preflight
 user-invocable: false
-version: 1.1.0
+version: 1.1.1
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
-metadata:
-  internal: true
 description: >
   Internal planning gate: consumes the normalized repository state and makes
   the ONE final architectural classification, using a two-stage contract that

--- a/skills/verification-contract/SKILL.md
+++ b/skills/verification-contract/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: verification-contract
 user-invocable: false
-version: 1.0.0
+version: 1.0.1
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
-metadata:
-  internal: true
 description: >
   Internal contract: one compact frozen ACCEPTANCE.md per delivery unit, its
   validation ladder, anti-weakening rules, and blob-bound execution receipt.


### PR DESCRIPTION
## Summary

- register `phase-contract`, `planning-preflight`, and `verification-contract` in the distribution manifest
- keep the runtime contracts out of the user-invocable menu without triggering the skills CLI internal-skill exclusion
- add a regression assertion for distributed runtime dependencies

## Validation

- `bunx skills add . --list` → 34 skills, including `verification-contract`
- `bunx skills add . -g -y` → `verification-contract` copied to `~/.agents/skills/verification-contract`
- `node scripts/bounded-delivery-loops.test.mjs`
- `node scripts/check-skill-context.test.mjs`
- `node scripts/check-skill-context.mjs --routes`
- `node scripts/dependency-gate.test.mjs`
- `node scripts/review-receipt.test.mjs`
- `node scripts/audit-pr-receipt.test.mjs`
- `git diff --check`

The CLI still reports a separate PromptScript limitation for global installs; Codex installation succeeds.
