### PR TITLE
fix(review-change): make receipt closeout a precondition

### DIFF
--- a/CHANGELOG.es.md
+++ b/CHANGELOG.es.md
@@ -285,6 +285,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 #### `review-change`
 | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|
+| 2.11.3 | 2026-08-10 | parche | Hace que el recibo PR verificado sea una precondición del informe de revisión, evitando que el bloque fijo termine el turno antes de publicar y releer el recibo. |
 | 2.11.2 | 2026-08-10 | parche | Hace explícito y fail-closed el cierre del recibo final de PR antes de que la review pueda recomendar `audit-pr`; aclara que el bloque fijo del informe no termina el turno. |
 | 2.11.1 | 2026-08-09 | parche | Sin cambio de comportamiento: comprime introducción, aislamiento, guardrails de rutas, relaciones y cierre, preservando aplicabilidad y contrato de solo lectura. |
 | 2.11.0 | 2026-08-09 | menor | Verifica el blob de aceptación congelado antes de la review y recomienda `loop-review-fold` acotado ante fallo, preservando su contrato de solo lectura y recibo ligado al SHA exacto. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -284,6 +284,7 @@ How pinning actually works, verified against the `skills` CLI:
 #### `review-change`
 | Version | Date | Type | What changed |
 |---|---|---|---|
+| 2.11.3 | 2026-08-10 | patch | Makes the verified PR receipt a precondition of the review report, preventing the fixed report from ending the turn before the receipt is posted and re-read. |
 | 2.11.2 | 2026-08-10 | patch | Makes the final PR receipt closeout explicit and fail-closed before the review can recommend `audit-pr`; clarifies that the fixed report block does not end the turn. |
 | 2.11.1 | 2026-08-09 | patch | No behavior change: compresses review introduction, isolation, route guardrails, relationships, and close-out prose while preserving applicability and read-only contracts. |
 | 2.11.0 | 2026-08-09 | minor | Verifies the frozen acceptance blob before review and recommends bounded `loop-review-fold` on failure while preserving its read-only, exact-SHA receipt contract. |

--- a/scripts/review-receipt.test.mjs
+++ b/scripts/review-receipt.test.mjs
@@ -63,7 +63,16 @@ const EMPTY = {};
 test("final PR REVIEW-PASS requires a posted and re-read current receipt", () => {
   assert.match(reviewSkill, /Decision: REVIEW-PASS \+ PR exists.*gh pr comment.*gh pr view/s);
   assert.match(reviewSkill, /must not recommend `\/audit-pr`/);
-  assert.match(persistAndDecide, /this is not the end of the turn.*run\s+step 13 before step 14/s);
+  assert.match(persistAndDecide, /receipt is a precondition of the report/);
+  assert.match(persistAndDecide, /After posting.*confirm\s+the newest marker equals the reviewed head SHA/s);
+});
+
+test("receipt closeout precedes the fixed report block", () => {
+  const receiptStep = persistAndDecide.indexOf("12. **Close out the final-review receipt before reporting.**");
+  const reportStep = persistAndDecide.indexOf("13. **Report block — Return exactly this structure**");
+  assert.ok(receiptStep >= 0, "receipt step must exist");
+  assert.ok(reportStep >= 0, "report step must exist");
+  assert.ok(receiptStep < reportStep, "the report must not be printed before the receipt is current");
 });
 
 test("REVIEW-PASS receipt body carries the exact marker and fixed fields", () => {

--- a/skills/review-change/SKILL.md
+++ b/skills/review-change/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-change
 user-invocable: true
-version: 2.11.2
+version: 2.11.3
 argument-hint: <path-or-glob> [--adversarial N] [--synthesize]
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
@@ -29,7 +29,9 @@ For a final PR review, the turn is incomplete until this additional box passes:
   `review-change:pass` marker is confirmed before printing `→ Next:`
 ```
 
-A clean report without that current receipt must not recommend `/audit-pr`.
+The receipt closeout is a precondition of the report, not a follow-up: do not
+print the fixed report block until the comment is current. A clean report
+without that current receipt must not recommend `/audit-pr`.
 
 Consume the internal [verification contract](<../verification-contract/SKILL.md>);
 the reviewer checks the same frozen `ACCEPTANCE.md` blob as the executor before
@@ -136,7 +138,8 @@ default; installed platform packs are optional. `triage-issue` is user-invoked
 only for independent proposals (D3). It is Stage 4: checkpoint reviews are
 optional, the end review is mandatory and fresh. `fix-now` folds in-unit,
 `replan-in-unit` adds user-confirmed phases, and independent work becomes
-proposals. `audit-pr` consumes the result; `product-audit` is the periodic sweep;
+proposals. `audit-pr` consumes only the verified PR-comment receipt, never the
+chat report; `product-audit` is the periodic sweep;
 `loop-review-fold` may run this skill fresh and route FAIL to `fold-findings`.
 
 ## Done when

--- a/skills/review-change/references/PERSIST_AND_DECIDE.md
+++ b/skills/review-change/references/PERSIST_AND_DECIDE.md
@@ -23,37 +23,28 @@
    their destinations from step 10 (outcome routing): independent future
    capabilities batch as proposals; only the user routes them to `triage-issue`
    (D3).
-12. **Report block — Return exactly this structure** (fixed chat-report block;
-   this is not the end of the turn). After printing its `Decision:` line, run
-   step 13 before step 14; the receipt action and verification are outside this
-   block:
+12. **Close out the final-review receipt before reporting.** First derive the
+   `Decision` from step 6 and persist step 11. Then, before printing any line of
+   the fixed report block or the `→ Next:` block, complete the receipt action
+   below. The receipt is a precondition of the report, not a follow-up.
 
-   ```
-   REVIEW CHANGE — scope: <scope>
-   Axes run: <list>   Skipped: <list + why>
-   Architectural invariants: pass | finding (<ID>) | n/a: no project invariants declared
+   The durable, audit-consumable receipt is one idempotent SHA-bound PR comment
+   (D6, D7). **Only on `Decision: REVIEW-PASS` AND when the PR exists** (the
+   mandatory final review; the PR always exists by then — the phase gate created
+   it). `REVIEW-FAIL` and `NEEDS-DECISION` post **no** passing receipt; continue
+   to step 13 after recording that status.
 
-   <the synthesized decision table (step 6)>
-
-   Manual verification (a human must check):
-   - <item> …
-
-   Proposals (step 10): <n> — batched for the user, no issues created (D3)
-
-   Summary: <1-2 sentences>
-   Decision: REVIEW-PASS | REVIEW-FAIL | NEEDS-DECISION   (D10: review says these three; only audit-pr says MERGE-READY)
-   ```
-
-13. **Post the final-review receipt.** The durable, audit-consumable receipt is
-   one idempotent SHA-bound PR comment (D6, D7). **Only on `Decision:
-   REVIEW-PASS` AND when the PR exists** (the mandatory final review; the PR
-   always exists by then — the phase gate created it). `REVIEW-FAIL` and
-   `NEEDS-DECISION` post **no** passing receipt; they take their step-11/14
-   paths instead. When it does fire, write the body below to a **temporary**
-   Markdown file (e.g. `$TMPDIR/review-receipt.md`), then post with
+   For `REVIEW-PASS` with a PR, write the body below to a **temporary** Markdown
+   file (e.g. `$TMPDIR/review-receipt.md`), then run
    `gh pr comment <N> --body-file <path>` — never inline `--body`, never commit
-   the file into the branch (D6: a review-report commit would invalidate its own
-   SHA). Use **exactly** this body:
+   the file into the branch. Before posting, run `gh pr view <N> --json comments`
+   and inspect the newest matching marker. Same SHA → skip the post; older or
+   absent SHA → post. After posting, run the same comment query again and confirm
+   the newest marker equals the reviewed head SHA. If that confirmation fails,
+   retry the receipt action; do not print a `REVIEW-PASS` report or recommend
+   `/audit-pr` while the receipt is not current.
+
+   Use **exactly** this body:
 
    ```markdown
    <!-- review-change:pass sha=<head SHA> contract=v1 -->
@@ -68,22 +59,34 @@
    - Manual verification: <items or none>
    ```
 
-   **Idempotent and exact-SHA:** before posting, list existing comments
-   (`gh pr view <N> --json comments`) and look for the newest
-   `<!-- review-change:pass sha=... contract=v1 -->` marker. Same SHA already
-   commented → **skip** (the receipt is already current; say so). Older SHA →
-   post the new comment (newest matching marker wins). Any later commit makes it
-   stale — the marker is bound to the head SHA it reviewed, and stale receipts
-   are rejected by audit-pr.
+13. **Report block — Return exactly this structure** after step 12 succeeds
+   (fixed chat-report block; this is not the end of the turn):
+
+   ```
+   REVIEW CHANGE — scope: <scope>
+   Axes run: <list>   Skipped: <list + why>
+   Architectural invariants: pass | finding (<ID>) | n/a: no project invariants declared
+   Receipt: current at <head SHA> | n/a: no PR | none: REVIEW-FAIL/NEEDS-DECISION
+
+   <the synthesized decision table (step 6)>
+
+   Manual verification (a human must check):
+   - <item> …
+
+   Proposals (step 10): <n> — batched for the user, no issues created (D3)
+
+   Summary: <1-2 sentences>
+   Decision: REVIEW-PASS | REVIEW-FAIL | NEEDS-DECISION   (D10: review says these three; only audit-pr says MERGE-READY)
+   ```
 
 14. **Next step.** The `→ Next:` block is **never one static template** — branch
-   on the `Decision` value from step 12 and emit the matching block **verbatim,
+   on the `Decision` value from step 6 and emit the matching block **verbatim,
    as multiple literal lines**. Never join the `·` sub-bullets into one prose
    line — each sub-bullet is its own line, exactly as quoted below.
 
    **`Decision: REVIEW-FAIL`** (any fix-now finding open) — the recommended line
    is the fold, never the merge gate. Findings were persisted in step 11; **no
-   passing receipt was posted** (step 13):
+   passing receipt was posted** (step 12):
 
    ```
    → Next: /loop-review-fold <unit> — repair compatible fix-now batches and
@@ -105,7 +108,7 @@
    ```
 
    **`Decision: REVIEW-PASS`** (table clean) — the recommended line is the merge
-   gate. Receipt: PR exists → posted in step 13 (exact-SHA `REVIEW-PASS` at
+   gate. Receipt: PR exists → current after step 12 (exact-SHA `REVIEW-PASS` at
    `<head SHA>`); pre-PR checkpoint → no receipt, the `progress.md` compact
    marker covers it (D7):
 
@@ -129,7 +132,7 @@
    ```
    → Next: decision required — the unit blocks until the user decides
      · present the decision-required finding(s) with evidence; no issue is
-       created (D3) and no passing receipt was posted (step 13)
+       created (D3) and no passing receipt was posted (step 12)
      · once the user decides, re-run /review-change on this same branch
    ```
 


### PR DESCRIPTION
## Summary
- make the SHA-bound review receipt a precondition of the fixed review report
- verify the newest exact-HEAD marker after posting before allowing the audit handoff
- add a regression assertion for the report/receipt ordering

## Verification
- node --test scripts/review-receipt.test.mjs
- node --test scripts/audit-pr-receipt.test.mjs
- all scripts/*.test.mjs
- node scripts/check-skill-context.mjs --skill review-change --skill audit-pr
- git diff --check