### PR TITLE
fix(skills): make next-step hand-offs complete

### DIFF
--- a/CHANGELOG.es.md
+++ b/CHANGELOG.es.md
@@ -234,6 +234,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 #### `plan-feature`
 | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|
+| 3.5.1 | 2026-08-10 | parche | Hace que los hand-offs por dependencias bloqueantes enumeren la cadena completa, de la más profunda a la final, en lugar de dejar un placeholder sin expandir. |
 | 3.5.0 | 2026-08-09 | menor | Los hand-offs limpios y ya-planificados recomiendan ahora `execute-phase` solo-con-objetivo para entregar la unidad completa y dejan `P1` explícita únicamente como alternativa atómica. |
 | 3.4.0 | 2026-08-04 | menor | Añade los contratos internos de un salto planning preflight y phase contract (rutas 2-3 de carga progresiva) y fija un único contexto de planificación inmutable — un snapshot del roadmap más payload opcional de issue — reutilizado entre internals compuestas, nunca re-consultado a mitad de plan. |
 | 3.3.2 | 2026-08-03 | parche | Hace explícito el contrato de routing derivado de issues: después de que `PLANNING_GATES.md` permita planificar, compone `plan-feature-from-issue` y después `plan-feature-scaffold`, en ese orden. |
@@ -261,6 +262,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 #### `plan-fix`
 | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|
+| 2.7.0 | 2026-08-10 | menor | Hace que el hand-off conserve explícitamente el alcance completo de una unidad multi-issue (`#primary + #n2 + …`) manteniendo el comando ejecutable ligado al issue primario. |
 | 2.6.1 | 2026-08-09 | parche | Sin cambio de comportamiento: comprime input/output, hard rules, carga progresiva, portabilidad y criterios de cierre, preservando agrupación multi-issue y contratos. |
 | 2.6.0 | 2026-08-09 | menor | Acepta bloques de capacidad compatibles y lotes mecánicos homogéneos usando comprobaciones de resultado, verificación, aislamiento, release/rollback y tamaño agregado; compartir ficheros/causa raíz/severidad deja de ser una puerta, y los conjuntos fallidos devuelven el mínimo número de grupos compatibles máximos. Emite `ACCEPTANCE.md` congelado. |
 | 2.5.0 | 2026-08-04 | menor | Consume el planning preflight compartido (lectura del estado normalizado del repositorio + una única clasificación arquitectónica final) y el phase contract (phase-lint canónico de 8 casillas + fingerprint de fase) antes de redactar y emitir un SPEC de fix; prosa comprimida para que la ruta se mantenga bajo su presupuesto base. |
@@ -285,6 +287,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 #### `review-change`
 | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|
+| 2.11.4 | 2026-08-10 | parche | Exige que los hand-offs REVIEW-FAIL y NEEDS-DECISION enumeren todos los IDs de findings afectados, en lugar de nombrar solo uno genérico o el primero. |
 | 2.11.2 | 2026-08-10 | parche | Hace explícito y fail-closed el cierre del recibo final de PR antes de que la review pueda recomendar `audit-pr`; aclara que el bloque fijo del informe no termina el turno. |
 | 2.11.1 | 2026-08-09 | parche | Sin cambio de comportamiento: comprime introducción, aislamiento, guardrails de rutas, relaciones y cierre, preservando aplicabilidad y contrato de solo lectura. |
 | 2.11.0 | 2026-08-09 | menor | Verifica el blob de aceptación congelado antes de la review y recomienda `loop-review-fold` acotado ante fallo, preservando su contrato de solo lectura y recibo ligado al SHA exacto. |
@@ -324,6 +327,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 #### `fold-findings`
 | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|
+| 1.2.2 | 2026-08-10 | parche | Exige que los hand-offs según resultado enumeren todos los IDs de findings afectados y su ruta. |
 | 1.2.1 | 2026-08-09 | parche | Sin cambio de comportamiento: comprime descubrimiento de cola, guardrails, portabilidad, relaciones y cierre; permanecen veredictos/tally y reglas de fold congeladas. |
 | 1.2.0 | 2026-08-09 | menor | Repara la cola seleccionada en lotes atómicos compatibles, conservando un veredicto y registro de evidencia por hallazgo; las disputas se detienen para decisión del usuario y ninguna ruta de fold crea issues automáticamente. |
 | 1.1.1 | 2026-08-02 | parche | Separa la política congelada del procedimiento por hallazgo tras rutas obligatorias de un salto y acorta metadatos de activación; clasificaciones, prohibiciones, veredictos y conducta de commit/push no cambian. |
@@ -333,6 +337,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 #### `loop-review-fold`
 | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|
+| 1.0.2 | 2026-08-10 | parche | Exige que las rutas no terminales de review/fold repitan todos los IDs de findings afectados en la recomendación de siguiente paso. |
 | 1.0.1 | 2026-08-09 | parche | Hace que el turno falle de forma cerrada ante casillas de contrato sin marcar y explicita los fallbacks de portabilidad para agentes que no usan Claude Code. |
 | 1.0.0 | 2026-08-09 | — | Nuevo conductor final acotado de review/corrección: reutiliza recibos al SHA exacto, alterna review de solo lectura y fold por lotes en contextos limpios solo para HEADs distintos, permite dos ciclos por defecto y se detiene al aprobar, requerir decisión, bloquearse, no progresar o agotar presupuesto. Nunca fusiona ni crea issues. |
 
@@ -369,6 +374,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 #### `product-audit`
 | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|
+| 3.0.3 | 2026-08-10 | parche | Exige que el hand-off de auditoría enumere el conjunto completo de findings antes de agrupar el triage. |
 | 3.0.2 | 2026-08-03 | parche | Carga la matriz de aplicabilidad de dimensiones antes de seleccionar las dimensiones de revisión, para que el Paso 0 no decida ejes incompletos antes de la lista autoritativa. |
 | 3.0.1 | 2026-08-02 | parche | Mueve las dimensiones de auditoría y el barrido de nueve pasos tras rutas obligatorias de un salto y elimina prosa repetida de activación manteniendo intactos el informe fijo persistido y el contrato solo-recomendación. |
 | 3.0.0 | 2026-07-31 | mayor | **Cambio incompatible de invocación:** este barrido costoso y solo de recomendación pasa a ser manual-only en Claude Code y OpenCode (`disable-model-invocation: true`, `opencode/autoinvoke: false`). La invocación explícita `/product-audit` no cambia; orquestadores y otras skills deben mantenerla como hand-off humano. |
@@ -415,6 +421,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 #### `triage-issue`
 | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|
+| 2.5.1 | 2026-08-10 | parche | Hace que los hand-offs de triage por lotes asignen a cada issue/finding su propio comando concreto siguiente. |
 | 2.5.0 | 2026-07-31 | menor | La carga progresiva selecciona primero issue del forge frente a hallazgo de auditoría persistido y después carga el detalle de propiedad de etiquetas y ledger de fold solo para los veredictos que lo necesitan. |
 | 2.4.0 | 2026-07-19 | menor | Nuevo **modo hallazgo-de-auditoría** (`triage-issue <audit-id> F<k> …`): tría hallazgos de un informe persistido de `product-audit` — re-verifica el hallazgo contra el código actual, deduplica contra issues existentes, abre el issue de GitHub solo con un veredicto fix-now/postpone/promote (el cuerpo cita `Origin: product audit <id>, finding F<k>`), y marca el hallazgo como triado en el fichero de auditoría con una nota datada `↳ triaged`. Las invocaciones por número de issue no cambian. |
 | 2.3.0 | 2026-07-18 | menor | Añade conciencia de unidad abierta (complemento del lado consumidor de `#66`): un chequeo de pertenencia de alcance se ejecuta antes de clasificar (enumerar unidades abiertas → comparación issue↔SPEC/fase citando ambos lados) y un quinto veredicto `fix-in-unit <unit>` resuelve los issues miembros en la propia rama de la unidad abierta — fold en su ledger `review-findings.md` (fila con marca de procedencia `triage #<n> <fecha>`) o en su fase actual/siguiente, un replan incremental (`design-feature`/`plan-feature`/una entrada `## Amendments` en el SPEC), o una restauración de scope-bleed. Los issues sin unidad se enrutan sin cambios, byte a byte. Corrige `#86`+`#87`. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,6 +233,7 @@ How pinning actually works, verified against the `skills` CLI:
 #### `plan-feature`
 | Version | Date | Type | What changed |
 |---|---|---|
+| 3.5.1 | 2026-08-10 | patch | Makes blocked dependency hand-offs enumerate the complete deepest-first dependency chain instead of leaving it as an unexpanded placeholder. |
 | 3.5.0 | 2026-08-09 | minor | Clean and already-planned hand-offs now recommend target-only `execute-phase` for whole-unit delivery and list explicit `P1` only as the atomic alternative. |
 | 3.4.0 | 2026-08-04 | minor | Adds the planning preflight and phase contract as one-hop internal contracts (progressive-loading paths 2-3) and pins a single immutable planning context — one roadmap snapshot plus optional issue payload — reused across composed internals, never re-fetched mid-plan. |
 | 3.3.2 | 2026-08-03 | patch | Makes the issue-derived routing contract explicit: after `PLANNING_GATES.md` permits planning, compose `plan-feature-from-issue` and then `plan-feature-scaffold` in that order. |
@@ -260,6 +261,7 @@ How pinning actually works, verified against the `skills` CLI:
 #### `plan-fix`
 | Version | Date | Type | What changed |
 |---|---|---|
+| 2.7.0 | 2026-08-10 | minor | Makes the hand-off preserve the complete multi-issue unit scope (`#primary + #n2 + …`) while keeping the executable command keyed to the primary issue. |
 | 2.6.1 | 2026-08-09 | patch | No behavior change: compresses input/output, hard-rule, progressive-loading, portability, and done-criteria prose while retaining multi-issue grouping semantics and contracts. |
 | 2.6.0 | 2026-08-09 | minor | Accepts compatible capability bundles and homogeneous mechanical issue batches using set-level outcome, verification, isolation, release/rollback, and aggregate-size checks; shared files/root cause/severity are no longer gates, and failed sets return the fewest maximal compatible groups. Emits frozen `ACCEPTANCE.md`. |
 | 2.5.0 | 2026-08-04 | minor | Consumes the shared planning preflight (normalized repository state read + one final architectural classification) and phase contract (canonical 8-box phase-lint + phase fingerprint) before drafting and emitting a fix SPEC; prose compressed so the route stays below its baseline budget. |
@@ -284,6 +286,7 @@ How pinning actually works, verified against the `skills` CLI:
 #### `review-change`
 | Version | Date | Type | What changed |
 |---|---|---|---|
+| 2.11.4 | 2026-08-10 | patch | Requires REVIEW-FAIL and NEEDS-DECISION hand-offs to enumerate every affected finding ID instead of naming only a generic or first finding. |
 | 2.11.2 | 2026-08-10 | patch | Makes the final PR receipt closeout explicit and fail-closed before the review can recommend `audit-pr`; clarifies that the fixed report block does not end the turn. |
 | 2.11.1 | 2026-08-09 | patch | No behavior change: compresses review introduction, isolation, route guardrails, relationships, and close-out prose while preserving applicability and read-only contracts. |
 | 2.11.0 | 2026-08-09 | minor | Verifies the frozen acceptance blob before review and recommends bounded `loop-review-fold` on failure while preserving its read-only, exact-SHA receipt contract. |
@@ -323,6 +326,7 @@ How pinning actually works, verified against the `skills` CLI:
 #### `fold-findings`
 | Version | Date | Type | What changed |
 |---|---|---|---|
+| 1.2.2 | 2026-08-10 | patch | Requires outcome hand-offs to enumerate every affected finding ID and its route. |
 | 1.2.1 | 2026-08-09 | patch | No behavior change: compresses queue discovery, guardrails, portability, relationships, and completion prose; fixed verdict/tally and frozen fold rules remain. |
 | 1.2.0 | 2026-08-09 | minor | Repairs the selected queue in compatible atomic batches while retaining one ledger verdict and evidence record per finding; disputes stop for user decision and no fold path auto-creates an issue. |
 | 1.1.1 | 2026-08-02 | patch | Splits frozen policy from the per-finding procedure behind mandatory one-hop routes and shortens activation metadata; classifications, forbidden actions, verdicts, and commit/push behavior are unchanged. |
@@ -332,6 +336,7 @@ How pinning actually works, verified against the `skills` CLI:
 #### `loop-review-fold`
 | Version | Date | Type | What changed |
 |---|---|---|---|
+| 1.0.2 | 2026-08-10 | patch | Requires non-terminal review/fold routes to repeat every affected finding ID in the next-step recommendation. |
 | 1.0.1 | 2026-08-09 | patch | Makes the turn fail-closed on unchecked contract boxes and states the non-Claude portability fallbacks in the user-facing skill. |
 | 1.0.0 | 2026-08-09 | — | New bounded final review/correction conductor: reuses exact-SHA receipts, alternates fresh read-only review and batched fold contexts only for changed HEADs, defaults to two correction cycles, and stops on pass, decision, blocker, no progress, or budget exhaustion. Never merges or creates issues. |
 
@@ -368,6 +373,7 @@ How pinning actually works, verified against the `skills` CLI:
 #### `product-audit`
 | Version | Date | Type | What changed |
 |---|---|---|---|
+| 3.0.3 | 2026-08-10 | patch | Requires the audit hand-off to enumerate the complete finding set before batching triage. |
 | 3.0.2 | 2026-08-03 | patch | Load the audit-dimensions applicability matrix before selecting review dimensions, so Step 0 cannot make an incomplete axis decision ahead of the authoritative list. |
 | 3.0.1 | 2026-08-02 | patch | Moves audit dimensions and the nine-step sweep behind mandatory one-hop routes and removes repeated activation prose while keeping the fixed persisted report and recommend-only contract intact. |
 | 3.0.0 | 2026-07-31 | major | **Breaking invocation change:** this high-cost, recommend-only sweep is manual-only on Claude Code and OpenCode (`disable-model-invocation: true`, `opencode/autoinvoke: false`). Explicit `/product-audit` invocation remains unchanged; orchestrators and other skills must keep it as a human hand-off. |
@@ -414,6 +420,7 @@ How pinning actually works, verified against the `skills` CLI:
 #### `triage-issue`
 | Version | Date | Type | What changed |
 |---|---|---|---|
+| 2.5.1 | 2026-08-10 | patch | Makes batched triage hand-offs map every issue/finding to its own concrete next command. |
 | 2.5.0 | 2026-07-31 | minor | Progressive loading selects forge-issue vs. persisted-audit input first, then loads label ownership and fold-ledger detail only for verdicts that need them. |
 | 2.4.0 | 2026-07-19 | minor | New **audit-finding mode** (`triage-issue <audit-id> F<k> …`): triages findings from a persisted `product-audit` report — re-verifies the finding against current code, dedupes against existing issues, opens the GitHub issue only on a fix-now/postpone/promote verdict (body cites `Origin: product audit <id>, finding F<k>`), and marks the finding triaged in the audit file with a dated `↳ triaged` note. Issue-number invocations are unchanged. |
 | 2.3.0 | 2026-07-18 | minor | Adds open-unit awareness (consumer-side complement of `#66`): a scope-membership check runs before classification (enumerate open units → both-sides-quoted issue↔SPEC/phase comparison) and a fifth verdict `fix-in-unit <unit>` resolves member issues on the open unit's own branch — fold into its `review-findings.md` ledger (provenance-marked `triage #<n> <date>` row) or its current/next phase, an incremental replan (`design-feature`/`plan-feature`/a SPEC `## Amendments` entry), or a scope-bleed restore. Non-member issues route byte-for-byte unchanged. Fixes `#86`+`#87`. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,14 @@ Body sections every skill follows: `When to use`, `Step 0 — Discover the proje
 > but every skill must run correctly on any agent and any model — see the README
 > model-equivalence table.
 
+> **Complete dynamic hand-offs.** When the invocation or artifact contains more
+> than one issue, dependency, finding, or other target, the closing recommendation
+> must name every actual ID once, in order, joined with ` + ` (for example,
+> `#71 + #72 + #73`). A command may use the designated primary when its syntax
+> requires one, but the full set must remain visible beside it. Never emit only
+> the primary, a generic "act on the verdicts", or literal placeholders/ellipsis
+> in a live hand-off.
+
 > **Turn contract at the top.** Every user-facing skill opens with a
 > `## Turn contract` section: the 2–6 boxes every invocation must tick before
 > the turn may end (the deliverable in its fixed format; the closing `→ Next:`

--- a/scripts/next-recommendations.test.mjs
+++ b/scripts/next-recommendations.test.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const readSkill = (name) =>
+  fs.readFileSync(path.join(repoRoot, "skills", name, "SKILL.md"), "utf8");
+const readReference = (skill, name) =>
+  fs.readFileSync(path.join(repoRoot, "skills", skill, "references", name), "utf8");
+
+test("plan-fix preserves the complete multi-issue unit in its hand-off", () => {
+  const skill = readSkill("plan-fix");
+  const process = readReference("plan-fix", "PLANNING_PROCESS.md");
+
+  assert.match(skill, /Issue set: #<primary> \+ #<n2> \+ #<n3>/);
+  assert.match(skill, /print every issue in this unit/);
+  assert.match(skill, /Replace every placeholder with the complete actual issue set/);
+  assert.match(process, /MULTI-ISSUE MERGE — #<primary> \+ #<n2> \+ #<n3>/);
+  assert.match(process, /Replace the placeholders with every actual issue number/);
+});
+
+test("plan-feature preserves every dependency in a blocked hand-off", () => {
+  const skill = readSkill("plan-feature");
+
+  assert.match(skill, /Dependency chain \(deepest first\): <deepest> \+ <dependency> \+ <NN>/);
+  assert.match(skill, /build the\s+complete dependency chain first: <deepest> \+ <dependency> \+ <NN>/);
+  assert.match(skill, /never print `…`/);
+});
+
+test("review and fold hand-offs preserve every finding ID", () => {
+  const review = readReference("review-change", "PERSIST_AND_DECIDE.md");
+  const reviewSkill = readSkill("review-change");
+  const fold = readSkill("fold-findings");
+
+  assert.match(reviewSkill, /list every open finding ID/);
+  assert.match(review, /all open fix-now findings: <F1> \+ <F2> \+ <F3>/);
+  assert.match(review, /resolve all open findings: <F1> \+ <F2> \+ <F3>/);
+  assert.match(fold, /list every affected finding ID once as `F1 \+ F2 \+ …`/);
+  assert.match(fold, /never\s+print `<F2>`, `…`, or a single representative ID/);
+});
+
+test("batch triage maps each issue to its own next command", () => {
+  const skill = readSkill("triage-issue");
+
+  assert.match(skill, /apply every verdict: #<n1> → <command> \+ #<n2> → <command> \+ #<n3> → <command>/);
+  assert.match(skill, /never collapses to one generic action/);
+  assert.match(skill, /Replace every placeholder with every actual issue\/finding ID/);
+});
+
+test("product audit and loop review preserve complete finding sets", () => {
+  const productAudit = readSkill("product-audit");
+  const loop = readSkill("loop-review-fold");
+  const policy = readReference("loop-review-fold", "LOOP_POLICY.md");
+
+  assert.match(productAudit, /Finding set: F<k> \+ F<j> \+ F<m>/);
+  assert.match(productAudit, /complete actual set/);
+  assert.match(loop, /every finding ID once, joined with ` \+ `/);
+  assert.match(policy, /repeat every affected finding ID once, joined with ` \+ `/);
+  assert.match(policy, /never print a literal placeholder or ellipsis/);
+});
+
+console.log("PASS next recommendations: complete issue, dependency, and finding sets are required");

--- a/skills/fold-findings/SKILL.md
+++ b/skills/fold-findings/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: fold-findings
 user-invocable: true
-version: 1.2.1
+version: 1.2.2
 argument-hint: [finding-id …]
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
@@ -33,6 +33,7 @@ skill fixes each root cause, never relabeling, deferring, or weakening its check
      `DISPUTED` with evidence for a user decision, never a silent drop/issue.
 ✓ 5. The closing `Folded: n/m · Disputed: k · Blocked: j[ · Replan: r]` tally
      and outcome-branched `→ Next:` block are printed as the ABSOLUTE last output.
+     Every affected finding ID is named in that block, joined with ` + `.
 ```
 
 Any unchecked box means the turn is not done.
@@ -129,9 +130,12 @@ finding belongs to a pushed atomic batch and ticked row. Nothing is reclassified
 or touched outside the queue.
 
 ```
-→ Next: (branches on outcome)
-  · all FOLDED → /review-change — re-review the branch now that findings are fixed
-  · any DISPUTED → user decision — resolve the evidenced dispute(s) without creating backlog
-  · any BLOCKED → supply the missing input listed above, then re-run /fold-findings
-  · any REPLAN → confirm the proposed SPEC phase(s), then /execute-phase on this same branch
+→ Next: (branches on outcome; list every affected finding ID once as `F1 + F2 + …`)
+  · all FOLDED (<F1> + <F2> + …) → /review-change — re-review the branch now that all listed findings are fixed
+  · any DISPUTED (<F1> + <F2> + …) → user decision — resolve every evidenced dispute without creating backlog
+  · any BLOCKED (<F1> + <F2> + …) → supply the listed missing inputs, then re-run /fold-findings
+  · any REPLAN (<F1> + <F2> + …) → confirm all proposed SPEC phases, then /execute-phase on this same branch
 ```
+
+Replace placeholders with every actual affected finding ID before printing; never
+print `<F2>`, `…`, or a single representative ID in a live hand-off.

--- a/skills/loop-review-fold/SKILL.md
+++ b/skills/loop-review-fold/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: loop-review-fold
 user-invocable: true
-version: 1.0.1
+version: 1.0.2
 argument-hint: <NN> | --fix <n> [--max-cycles N] [--adversarial N]
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
@@ -27,6 +27,7 @@ its candidate.
 ✓ At most --max-cycles correction cycles ran (default 2); no hidden retry budget
 ✓ No issue or merge command ran; independent work remained proposals
 ✓ One terminal state and its evidence were printed; closing → Next: block was last
+✓ When findings are open, the matching terminal recommendation names every finding ID once, joined with ` + `
 ```
 
 Any unchecked box means the turn is not done.
@@ -82,5 +83,5 @@ classification, ledger, or correction checklists into this skill.
 - Every non-PASS state names a deterministic resume or decision path.
 
 ```text
-→ Next: (terminal-dependent; use LOOP_POLICY.md's exact block)
+→ Next: (terminal-dependent; use LOOP_POLICY.md's exact block and repeat every open finding ID joined with ` + `)
 ```

--- a/skills/loop-review-fold/references/LOOP_POLICY.md
+++ b/skills/loop-review-fold/references/LOOP_POLICY.md
@@ -54,16 +54,18 @@ LOOP REVIEW FOLD — <PASS|NEEDS-DECISION|BLOCKED|NO-PROGRESS|BUDGET-EXHAUSTED>
 Unit: <unit> · PR: <url> · HEAD: <sha>
 Acceptance: <blob> (<match|mismatch>)
 Reviews: <n> · Correction cycles: <used>/<max>
-Open findings: <ids|none> · Receipt: <current sha|none>
+Open findings: <F1 + F2 + …|none> · Receipt: <current sha|none>
 Evidence: <one concise line>
 
-→ Next: <terminal mapping>
+→ Next: <terminal mapping; repeat every affected finding ID once, joined with ` + `>
   · PASS → /audit-pr — delivery/merge gate
-  · NEEDS-DECISION → resolve the named decision, then re-run /loop-review-fold <unit>
-  · BLOCKED → supply/fix the named prerequisite, then re-run the same command
-  · NO-PROGRESS → inspect the repeated validator/finding; use an explicit stronger-model fold or decide
-  · BUDGET-EXHAUSTED → inspect the remaining findings; raise the budget only with a concrete correction hypothesis
+  · NEEDS-DECISION (<F1> + <F2> + …) → resolve all named decisions, then re-run /loop-review-fold <unit>
+  · BLOCKED (<F1> + <F2> + …) → supply/fix all named prerequisites, then re-run the same command
+  · NO-PROGRESS (<F1> + <F2> + …) → inspect all repeated findings; use an explicit stronger-model fold or decide
+  · BUDGET-EXHAUSTED (<F1> + <F2> + …) → inspect all remaining findings; raise the budget only with a concrete correction hypothesis
 ```
 
 Print only the matching recommended line first; retain the other applicable
-alternatives as sub-bullets. Never recommend audit on a non-PASS state.
+alternatives as sub-bullets. Replace placeholders with every actual finding ID
+before printing; never print a literal placeholder or ellipsis. Never recommend
+audit on a non-PASS state.

--- a/skills/plan-feature/SKILL.md
+++ b/skills/plan-feature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan-feature
 user-invocable: true
-version: 3.5.0
+version: 3.5.1
 argument-hint: <NN-slug | #N> | --from-issue N | --scaffold <slug> | --next
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
@@ -31,6 +31,7 @@ one — the routed redirect gate enforces that split.
   AFTER the write and literally reads `planned` — a dropped `defined→planned`
   write fails this box; do not end the turn until it's fixed
 ✓ The dependency & blocker check was RUN and its result decides which closing block is printed
+✓ An unmet dependency? The closing block lists the complete dependency chain, deepest first, joined with ` + `
 ✓ Artifact language: explicit user instruction > the project's declared docs language > English. The CONVERSATION language never decides — a Spanish prompt still produces English PRs/issues/commits/SPECs unless one of the first two says otherwise
 ✓ The closing `→ Next:` block is printed as the ABSOLUTE last output
 ```
@@ -170,8 +171,9 @@ enables:
   unmet dependency and/or blocking fix-now issue:
 
   ```
-  → Next: /plan-feature <deepest-unmet-dep> (or /execute-phase <dep> …) — build the
-    dependency chain first: <chain, deepest → NN>
+  Dependency chain (deepest first): <deepest> + <dependency> + <NN> (replace with every actual member; never print `…`)
+  → Next: /plan-feature <deepest-unmet-dep> (or /execute-phase <deepest-unmet-dep>) — build the
+    complete dependency chain first: <deepest> + <dependency> + <NN>
     · blocking fix-now issue #<n> in the same area → /plan-fix <n> before executing
     · proceed anyway → /execute-phase <NN> --force (the gate logs the override)
   ```

--- a/skills/plan-fix/SKILL.md
+++ b/skills/plan-fix/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan-fix
 user-invocable: true
-version: 2.6.1
+version: 2.7.0
 argument-hint: <issue-number> [<issue-number> …]
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
@@ -21,6 +21,7 @@ stop for review, then `execute-phase --fix` implements every remaining phase.
 ```
 ✓ The fix SPEC is committed on its `fix/<n>-<topic>` branch (commit sha pasted) — NOT pushed, NO PR
 ✓ The Hand-off block was printed exactly as specified
+✓ A multi-issue unit? The hand-off names every issue once as `#primary + #n2 + …`; a single-issue unit names only its issue
 ✓ Artifact language: explicit user instruction > the project's declared docs language > English. The CONVERSATION language never decides — a Spanish prompt still produces English artifacts unless one of the first two says otherwise
 ✓ The closing `→ Next:` block is printed as the ABSOLUTE last output
 ```
@@ -87,13 +88,17 @@ After commit, print exactly:
 SPEC drafted: docs/fix/<primary>-<topic>/SPEC.md
 Branch: fix/<primary>-<topic> (local, not pushed)
 Commit: <short hash>
+Issue set: #<primary> + #<n2> + #<n3> (print every issue in this unit; single issue → #<primary>)
 
-→ Next: review the SPEC, then /execute-phase --fix <primary> — execute every remaining phase and open the PR
-  · explicit atomic mode → /execute-phase --fix <primary> P<n>
+→ Next: review the SPEC, then /execute-phase --fix <primary> — execute every remaining phase in issue set #<primary> + #<n2> + #<n3> and open the PR
+  · explicit atomic mode → /execute-phase --fix <primary> P<n> (same issue set: #<primary> + #<n2> + #<n3>)
   · the final `Hardening & PR` phase pushes and opens the PR with `Closes #<primary>`
-    (and `Closes #<n2>`, `Closes #<n3>`, … — one line per merged issue, when applicable)
+    plus one `Closes #<n>` line for every other issue listed in the Issue set
   · scope looks wrong → adjust the SPEC and re-run /plan-fix
 ```
+
+Replace every placeholder with the complete actual issue set before printing;
+never print `<n2>`, `<n3>`, or `…` in a live hand-off.
 
 Then end in the user's language with a 2-3 sentence summary: what the SPEC ships, the biggest risk, and any open decisions left for the implementer.
 

--- a/skills/plan-fix/references/PLANNING_PROCESS.md
+++ b/skills/plan-fix/references/PLANNING_PROCESS.md
@@ -49,7 +49,7 @@
    the PR later uses one `Closes #<n>` line per issue. Print exactly:
 
    ```text
-   MULTI-ISSUE MERGE — #<primary> (+#<n2>, #<n3>, …)
+   MULTI-ISSUE MERGE — #<primary> + #<n2> + #<n3>
    Atomic-delivery mode: <capability bundle|homogeneous mechanical batch>
    Checklist: ALL 5 boxes ticked
      ✓ shared outcome/rule: <one sentence>
@@ -58,11 +58,14 @@
      ✓ no isolation conflict: <evidence>
      ✓ aggregate size: <XS|S|M>
    Unit: docs/fix/<primary>-<topic>/SPEC.md
-   Issues merged: #<primary> (primary), #<n2>, #<n3>, …
+   Issues merged: #<primary> (primary) + #<n2> + #<n3>
    PR will carry: Closes #<primary>
                  Closes #<n2>
-                 Closes #<n3>
+   Closes #<n3>
    ```
+
+   Replace the placeholders with every actual issue number before printing;
+   use ` + ` between all members and never print a literal ellipsis.
 
    Any box fails → write nothing. Partition the input into the **fewest maximal
    compatible groups** that do pass (singletons only when no bundle exists),

--- a/skills/product-audit/SKILL.md
+++ b/skills/product-audit/SKILL.md
@@ -2,7 +2,7 @@
 name: product-audit
 user-invocable: true
 disable-model-invocation: true
-version: 3.0.2
+version: 3.0.3
 metadata:
   opencode/autoinvoke: false
 argument-hint: <path-or-area> (optional — defaults to the whole product)
@@ -129,10 +129,14 @@ Verdict: <one-line honest health verdict>
 ## Manual-verification checklist (what automation can't confirm)
   - <item> …
 
-→ Next: /triage-issue <id> F<k> F<j> … — classify the proposed issues in one batch (opens the ones that warrant it)
+Finding set: F<k> + F<j> + F<m> (print every proposed finding; one finding → F<k>)
+→ Next: /triage-issue <id> F<k> F<j> F<m> — classify the complete finding set in one batch (opens the ones that warrant it)
   · accepted bug/debt → /plan-fix   · accepted capability → /plan-feature
   · nothing to act on → the persisted report is the record; move on
 ```
+
+Replace every finding placeholder with the complete actual set before printing;
+never print `…` or only the first finding in a live hand-off.
 
 `<id>` is the audit's incremental number (Process step 8). A finding is
 addressable forever as `<audit-id> F<k>` — e.g. `triage-issue 3 F2` reads

--- a/skills/review-change/SKILL.md
+++ b/skills/review-change/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-change
 user-invocable: true
-version: 2.11.2
+version: 2.11.4
 argument-hint: <path-or-glob> [--adversarial N] [--synthesize]
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
@@ -30,6 +30,10 @@ For a final PR review, the turn is incomplete until this additional box passes:
 ```
 
 A clean report without that current receipt must not recommend `/audit-pr`.
+
+For `REVIEW-FAIL` or `NEEDS-DECISION`, list every open finding ID in the closing
+recommendation, joined with ` + `; the review must never hand off only the first
+finding.
 
 Consume the internal [verification contract](<../verification-contract/SKILL.md>);
 the reviewer checks the same frozen `ACCEPTANCE.md` blob as the executor before

--- a/skills/review-change/references/PERSIST_AND_DECIDE.md
+++ b/skills/review-change/references/PERSIST_AND_DECIDE.md
@@ -80,14 +80,16 @@
    on the `Decision` value from step 12 and emit the matching block **verbatim,
    as multiple literal lines**. Never join the `·` sub-bullets into one prose
    line — each sub-bullet is its own line, exactly as quoted below.
+   For `REVIEW-FAIL` or `NEEDS-DECISION`, list every open finding ID in the
+   closing recommendation, joined with ` + `; never hand off only the first.
 
    **`Decision: REVIEW-FAIL`** (any fix-now finding open) — the recommended line
    is the fold, never the merge gate. Findings were persisted in step 11; **no
    passing receipt was posted** (step 13):
 
    ```
-   → Next: /loop-review-fold <unit> — repair compatible fix-now batches and
-     re-review changed HEADs within the bounded correction budget
+   → Next: /loop-review-fold <unit> — repair all open fix-now findings: <F1> + <F2> + <F3>,
+     then re-review changed HEADs within the bounded correction budget
      · manual path → /fold-findings, then re-run /review-change
      · /audit-pr → only after the table is clean (not yet — findings open)
       · any finding routed replan-in-unit? → confirm the proposed SPEC phase(s),
@@ -127,7 +129,8 @@
    alone resolves it:
 
    ```
-   → Next: decision required — the unit blocks until the user decides
+   → Next: decision required — resolve all open findings: <F1> + <F2> + <F3>
+     before the unit continues
      · present the decision-required finding(s) with evidence; no issue is
        created (D3) and no passing receipt was posted (step 13)
      · once the user decides, re-run /review-change on this same branch

--- a/skills/triage-issue/SKILL.md
+++ b/skills/triage-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: triage-issue
 user-invocable: true
-version: 2.5.0
+version: 2.5.1
 argument-hint: <issue-number> [more issue numbers…] | <audit-id> F<k> [F<j>…]
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
@@ -23,6 +23,7 @@ premature work (acting on a deferred item whose trigger is unmet) and silent rot
 ✓ One fixed-format verdict block per issue (Trigger / Checked / Evidence / VERDICT / Action) — plus the summary table when batched
 ✓ Nothing deferred was implemented inline
 ✓ Audit-finding mode (`<audit-id> F<k>`): the audit file carries its `↳ triaged` note, and any opened issue cites `Origin: product audit <id>, finding F<k>`
+✓ Batched input? The closing recommendation maps every issue/finding ID to its own next command, joined with ` + `; it never collapses to one generic action
 ✓ Artifact language: explicit user instruction > the project's declared docs language > English. The CONVERSATION language never decides — a Spanish prompt still produces English PRs/issues/commits/SPECs unless one of the first two says otherwise
 ✓ The closing `→ Next:` block is printed as the ABSOLUTE last output
 ```
@@ -111,14 +112,20 @@ triage-issue ────┤                    or fold-findings (ledger row)
 - **The closing `→ Next:` block is printed** per verdict:
 
   ```
-  → Next: act on the verdict(s)
-    · fix-now → /plan-fix   · promote → /plan-feature
-    · fix-in-unit → /execute-phase <NN> P<k> (fold into phase) or
-      /fold-findings (ledger row) — never /plan-fix
+  Single issue:
+  → Next: <command for the recorded verdict> — act on the issue's evidence-backed action
+
+  Batch:
+  → Next: apply every verdict: #<n1> → <command> + #<n2> → <command> + #<n3> → <command>
+    · fix-now → /plan-fix <n>   · promote → /plan-feature <n>
+    · fix-in-unit → /execute-phase <NN> P<k> or /fold-findings — never /plan-fix
     · postpone → dated comment, leave open   · wontfix → propose close
     · same inconsistency across several issues → /product-audit (a recurring pattern,
       not isolated tickets — sweep the product rather than triaging one by one)
   ```
+
+  Replace every placeholder with every actual issue/finding ID and its recorded
+  route before printing; never print `<n2>`, `<command>`, or `…` in a live batch.
 
   The `/product-audit` line fires **only on a recurring inconsistency** — the same
   underlying problem behind multiple issues, not any single triage.


### PR DESCRIPTION
## Summary
- require multi-issue, dependency, finding, and batch hand-offs to enumerate the complete target set with ` + `
- keep executable commands keyed to the primary target where syntax requires it while preserving all related IDs
- add regression coverage for planning, review/fold, product-audit, loop-review-fold, and triage routes

## Validation
- `node --test scripts/next-recommendations.test.mjs`
- `node scripts/check-skill-context.mjs --skill plan-fix --skill plan-feature --skill review-change --skill fold-findings --skill triage-issue --skill product-audit --skill loop-review-fold`
- full `scripts/*.test.mjs` suite
- `npx skills add . --list`
- `git diff --check`