### PR TITLE
docs: document complete agentic-workflow uninstall

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -638,6 +638,29 @@ npx skills add gtrabanco/agentic-workflow#release-2026-07-02
 #   Ver CHANGELOG.es.md → "Instalar y pinear una versión" para cómo funciona el pinning.
 ```
 
+## Desinstalación
+
+Para eliminar la instalación completa de `agentic-workflow` del proyecto actual
+sin seleccionar las skills de forma interactiva, pasa todos los nombres de las
+skills publicadas a un único comando `remove`:
+
+```sh
+npx skills remove --yes \
+  audit-docs audit-pr design-feature discover-repository-state execute-phase \
+  fold-findings generate-docs init-workspace log-session loop-review-fold \
+  orchestration-envelope phase-contract plan-feature plan-feature-from-issue \
+  plan-feature-scaffold plan-fix planning-preflight product-audit \
+  resolve-repository-state review-a11y review-brand review-change review-code \
+  review-debt review-design review-implementation review-perf review-security \
+  review-seo review-verify ship-roadmap triage-issue verification-contract \
+  workflow-status
+```
+
+Usa el mismo comando con `--global` para eliminar la instalación global. El
+comando solo afecta a estos nombres de `agentic-workflow`; las skills ajenas
+permanecen instaladas. Evita `npx skills remove --all` salvo que quieras
+eliminar todas las skills instaladas en ese ámbito.
+
 ### Actualizar una instalación existente
 
 `npx skills add …` / `npx skills update` solo refresca las **skills**

--- a/README.md
+++ b/README.md
@@ -607,6 +607,29 @@ npx skills add gtrabanco/agentic-workflow#release-2026-07-02
 #   See CHANGELOG.md → "Installing & pinning a version" for how pinning works.
 ```
 
+## Uninstall
+
+To remove the complete `agentic-workflow` install from the current project
+without selecting skills interactively, pass all published skill names to one
+`remove` command:
+
+```sh
+npx skills remove --yes \
+  audit-docs audit-pr design-feature discover-repository-state execute-phase \
+  fold-findings generate-docs init-workspace log-session loop-review-fold \
+  orchestration-envelope phase-contract plan-feature plan-feature-from-issue \
+  plan-feature-scaffold plan-fix planning-preflight product-audit \
+  resolve-repository-state review-a11y review-brand review-change review-code \
+  review-debt review-design review-implementation review-perf review-security \
+  review-seo review-verify ship-roadmap triage-issue verification-contract \
+  workflow-status
+```
+
+Use the same command with `--global` to remove the global installation. The
+command targets only these `agentic-workflow` names; unrelated skills remain
+installed. Avoid `npx skills remove --all` unless you intend to remove every
+skill installed in that scope.
+
 ### Updating an existing install
 
 `npx skills add …` / `npx skills update` only refreshes the **skills**


### PR DESCRIPTION
## Summary
- add an English and Spanish Uninstall section to the README
- provide one non-interactive `npx skills remove --yes` command covering all 34 published agentic-workflow skills
- document the `--global` variant and warn that `--all` removes unrelated skills too

## Validation
- `git diff --check`
- verified the command list matches `.claude-plugin/plugin.json` exactly (34 skills)
- `npx skills remove --help` confirms space-separated multi-skill removal and `--yes`/`--global` options