### PR TITLE
docs: explain legacy skill lock cleanup

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -653,13 +653,35 @@ npx skills remove --yes \
   resolve-repository-state review-a11y review-brand review-change review-code \
   review-debt review-design review-implementation review-perf review-security \
   review-seo review-verify ship-roadmap triage-issue verification-contract \
-  workflow-status
+  workflow-status plan-feature-interview bump-skill
 ```
 
 Usa el mismo comando con `--global` para eliminar la instalación global. El
 comando solo afecta a estos nombres de `agentic-workflow`; las skills ajenas
-permanecen instaladas. Evita `npx skills remove --all` salvo que quieras
-eliminar todas las skills instaladas en ese ámbito.
+permanecen instaladas. Los dos últimos nombres son entradas legacy retiradas
+que se incluyen para limpiar lockfiles antiguos. Evita
+`npx skills remove --all` salvo que quieras eliminar todas las skills instaladas
+en ese ámbito.
+
+Para instalaciones creadas antes de retirar `plan-feature-interview` o excluir
+la skill interna `bump-skill`, el comando anterior también limpia sus entradas
+legacy del lockfile.
+
+### Reparar una instalación antigua
+
+`npx skills add` actualiza las skills existentes, pero no elimina los nombres
+retirados de un `skills-lock.json` existente. Si el instalador informa de una
+skill declarada en el lockfile pero ausente del disco, elimina las entradas
+retiradas y reinstala:
+
+```sh
+npx skills remove --yes plan-feature-interview bump-skill
+npx skills add gtrabanco/agentic-workflow
+```
+
+Para una instalación global, añade `--global` a ambos comandos. Estos nombres
+no los publica el pack actual: `plan-feature-interview` fue sustituida por
+`design-feature`, y `bump-skill` es interna del repositorio.
 
 ### Actualizar una instalación existente
 

--- a/README.es.md
+++ b/README.es.md
@@ -680,8 +680,9 @@ npx skills add gtrabanco/agentic-workflow
 ```
 
 Para una instalación global, añade `--global` a ambos comandos. Estos nombres
-no los publica el pack actual: `plan-feature-interview` fue sustituida por
-`design-feature`, y `bump-skill` es interna del repositorio.
+no los publica el pack actual: `plan-feature-interview` fue una helper interna
+instalada por versiones antiguas antes de mover su lógica a `design-feature`, y
+`bump-skill` fue reclasificada después como interna del repositorio.
 
 ### Actualizar una instalación existente
 

--- a/README.md
+++ b/README.md
@@ -647,8 +647,9 @@ npx skills add gtrabanco/agentic-workflow
 ```
 
 For a global installation, add `--global` to both commands. These names are not
-published by the current pack: `plan-feature-interview` was replaced by
-`design-feature`, and `bump-skill` is repository-internal.
+published by the current pack: `plan-feature-interview` was an internal helper
+installed by older releases before its logic moved to `design-feature`, and
+`bump-skill` was later reclassified as repository-internal.
 
 ### Updating an existing install
 

--- a/README.md
+++ b/README.md
@@ -622,13 +622,33 @@ npx skills remove --yes \
   resolve-repository-state review-a11y review-brand review-change review-code \
   review-debt review-design review-implementation review-perf review-security \
   review-seo review-verify ship-roadmap triage-issue verification-contract \
-  workflow-status
+  workflow-status plan-feature-interview bump-skill
 ```
 
 Use the same command with `--global` to remove the global installation. The
 command targets only these `agentic-workflow` names; unrelated skills remain
-installed. Avoid `npx skills remove --all` unless you intend to remove every
-skill installed in that scope.
+installed. The final two names are retired legacy entries included to clean
+older lockfiles. Avoid `npx skills remove --all` unless you intend to remove
+every skill installed in that scope.
+
+For installations created before the retirement of `plan-feature-interview` or
+the internal exclusion of `bump-skill`, the command above also clears their
+legacy lock entries.
+
+### Repairing an older install
+
+`npx skills add` refreshes existing skills but does not prune retired names from
+an existing `skills-lock.json`. If the installer reports a skill claimed in the
+lockfile but missing on disk, remove the retired entries and reinstall:
+
+```sh
+npx skills remove --yes plan-feature-interview bump-skill
+npx skills add gtrabanco/agentic-workflow
+```
+
+For a global installation, add `--global` to both commands. These names are not
+published by the current pack: `plan-feature-interview` was replaced by
+`design-feature`, and `bump-skill` is repository-internal.
 
 ### Updating an existing install
 

--- a/scripts/bounded-delivery-loops.test.mjs
+++ b/scripts/bounded-delivery-loops.test.mjs
@@ -60,6 +60,12 @@ assert.match(verification, /git hash-object/);
 assert.match(verification, /deleting, skipping, narrowing, or loosening a validator/);
 
 const pluginSkills = plugin.skills.map((entry) => entry.replace("./skills/", ""));
+assert.ok(!pluginSkills.includes("bump-skill"), "bump-skill is repository-internal and must not be distributed");
+assert.ok(!pluginSkills.includes("plan-feature-interview"), "plan-feature-interview is retired and must not be distributed");
+assert.equal(fs.existsSync(path.join(root, "skills", "plan-feature-interview")), false,
+  "retired plan-feature-interview must remain absent from the source tree");
+assert.match(read("skills/bump-skill/SKILL.md"), /^user-invocable: false$/m);
+assert.match(read("skills/bump-skill/SKILL.md"), /^  internal: true$/m);
 for (const requiredDependency of ["loop-review-fold", "phase-contract", "planning-preflight", "verification-contract"]) {
   assert.ok(pluginSkills.includes(requiredDependency), `${requiredDependency} must be distributed by plugin.json`);
 }


### PR DESCRIPTION
## Summary
- document that `npx skills add` does not prune retired names from an existing `skills-lock.json`
- include `plan-feature-interview` and `bump-skill` in the one-command uninstall cleanup
- provide the exact repair sequence for the reported missing-on-disk claims in English and Spanish

## Validation
- reproduced the stale-lock symptom with the current `skills` CLI
- verified `npx skills remove --yes plan-feature-interview bump-skill` removes both stale entries
- verified the uninstall command lists all 34 current skills plus both legacy names
- `git diff --check`