### PR TITLE
fix(skills): bind review receipts to PR head

### DIFF
--- a/CHANGELOG.es.md
+++ b/CHANGELOG.es.md
@@ -287,6 +287,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 #### `review-change`
 | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|
+| 2.11.5 | 2026-08-11 | parche | Congela el commit revisado y exige que el `headRefOid` de la PR coincida antes de publicar un recibo REVIEW-PASS; si el head de la PR cambia, se re-revisa en vez de publicar un recibo irresoluble. |
 | 2.11.3 | 2026-08-10 | parche | Hace que el recibo PR verificado sea una precondición del informe de revisión, evitando que el bloque fijo termine el turno antes de publicar y releer el recibo. |
 | 2.11.4 | 2026-08-10 | parche | Exige que los hand-offs REVIEW-FAIL y NEEDS-DECISION enumeren todos los IDs de findings afectados, en lugar de nombrar solo uno genérico o el primero. |
 | 2.11.2 | 2026-08-10 | parche | Hace explícito y fail-closed el cierre del recibo final de PR antes de que la review pueda recomendar `audit-pr`; aclara que el bloque fijo del informe no termina el turno. |
@@ -345,6 +346,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 #### `audit-pr`
 | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|
+| 4.3.1 | 2026-08-11 | parche | Obtiene `headRefOid` junto con los comentarios de la PR y acepta un recibo REVIEW-PASS solo en ese snapshot exacto; cualquier diferencia de SHA es obsoleta y se enruta a una revisión nueva. |
 | 4.3.0 | 2026-08-05 | menor | **Consume el recibo de revisión de `review-change`** en lugar de re-revisar el diff (feature 21): el Paso 1 obtiene los comentarios del PR y toma el marcador `<!-- review-change:pass sha=<40-hex> contract=v1 -->` más nuevo; un recibo vigente se reconoce como la evidencia de revisión, uno ausente/obsoleto es un bloqueante enrutado a `/review-change` (nunca se re-revisa aquí). Las puertas de merge se estrechan al conjunto solo-auditoría del SPEC — se retira la puerta `Tests` (calidad de pruebas) y el re-mapeo de criterios de aceptación por diff (sustituido por el campo de cobertura de aceptación del recibo); la puerta de Invariantes arquitectónicas ahora refleja el resultado del recibo en lugar de reclasificar. Pasos de proceso renumerados; el comentario MERGE-READY cita el recibo consumido. Requiere un `review-change` que publique el recibo ligado al SHA; las versiones antiguas de `review-change` dejan a audit-pr bloqueado sin recibo en el head. |
 | 4.2.0 | 2026-07-31 | menor | Sincroniza el contrato consumidor de merge con la frontera de autoridad fullauto verificable desde el forge; las auditorías standalone siguen limitadas a veredicto/comentario. |
 | 4.1.0 | 2026-07-31 | menor | La carga progresiva mueve gates de merge, checks de cierre/descope, proceso de auditoría, veredicto fijo, enrutamiento/guardrails y portabilidad detrás de una ruta de auditoría obligatoria de un salto; la propiedad del merge permanece en el entrypoint. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,7 @@ How pinning actually works, verified against the `skills` CLI:
 #### `review-change`
 | Version | Date | Type | What changed |
 |---|---|---|---|
+| 2.11.5 | 2026-08-11 | patch | Freezes the reviewed commit and requires the PR's `headRefOid` to match it before publishing a REVIEW-PASS receipt; a changed PR head is re-reviewed instead of receiving an unresolvable receipt. |
 | 2.11.3 | 2026-08-10 | patch | Makes the verified PR receipt a precondition of the review report, preventing the fixed report from ending the turn before the receipt is posted and re-read. |
 | 2.11.4 | 2026-08-10 | patch | Requires REVIEW-FAIL and NEEDS-DECISION hand-offs to enumerate every affected finding ID instead of naming only a generic or first finding. |
 | 2.11.2 | 2026-08-10 | patch | Makes the final PR receipt closeout explicit and fail-closed before the review can recommend `audit-pr`; clarifies that the fixed report block does not end the turn. |
@@ -344,6 +345,7 @@ How pinning actually works, verified against the `skills` CLI:
 #### `audit-pr`
 | Version | Date | Type | What changed |
 |---|---|---|---|
+| 4.3.1 | 2026-08-11 | patch | Fetches `headRefOid` with PR comments and accepts a REVIEW-PASS receipt only on that exact snapshot; any SHA mismatch is stale and routes to a fresh review. |
 | 4.3.0 | 2026-08-05 | minor | **Consumes the `review-change` review receipt** instead of re-reviewing the diff (feature 21): Step 1 fetches the PR's comments and takes the newest `<!-- review-change:pass sha=<40-hex> contract=v1 -->` marker; a current receipt is acknowledged as the review evidence, an absent/stale one is a blocker routed to `/review-change` (never re-reviewed here). The merge gates narrow to the SPEC's audit-only set — dropped the `Tests` (test-quality) gate and the acceptance-criteria diff-remapping (replaced by the receipt's acceptance-coverage field); the Architectural-invariants gate now mirrors the receipt's result instead of reclassifying. Process steps renumbered; the MERGE-READY comment cites the consumed receipt. Requires a `review-change` that posts the SHA-bound receipt; older `review-change` versions leave audit-pr blocked with no receipt at the head. |
 | 4.2.0 | 2026-07-31 | minor | Synchronizes the merge-consumer contract with the forge-verifiable fullauto authority boundary; standalone audits remain verdict/comment-only. |
 | 4.1.0 | 2026-07-31 | minor | Progressive loading moves merge gates, closure/descope checks, audit process, fixed verdict, routing/guardrails, and portability behind a mandatory one-hop audit route; merge ownership remains in the entrypoint. |

--- a/scripts/audit-pr-receipt.test.mjs
+++ b/scripts/audit-pr-receipt.test.mjs
@@ -1,7 +1,14 @@
 #!/usr/bin/env node
 
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const auditSkill = fs.readFileSync(path.join(repoRoot, "skills/audit-pr/SKILL.md"), "utf8");
+const auditProcess = fs.readFileSync(path.join(repoRoot, "skills/audit-pr/references/03_AUDIT_PROCESS.md"), "utf8");
 
 const REVIEW_CONTRACT = "v1";
 const REVIEW_MARKER_RE = /<!-- review-change:pass sha=([0-9a-f]{40}) contract=([^ ]+) -->/;
@@ -128,6 +135,13 @@ test("stale receipt (any later commit) → BLOCKED routed to /review-change; no 
   assert.equal(result.route, "/review-change");
   assert.equal(result.gatesEvaluated, false);
   assert.equal(receiptStatus([{ body: reviewBody({ sha: oldSha, scope: "s", axes: "a", coverage: "c", invariants: "pass", proposals: "0", manual: "none" }) }], headSha).status, "stale");
+});
+
+test("audit-pr fetches the PR head with comments and treats every SHA mismatch as stale", () => {
+  assert.match(auditSkill, /--json[^\n]*headRefOid[^\n]*comments|--json[^\n]*comments[^\n]*headRefOid/);
+  assert.match(auditProcess, /headRefOid.*current head SHA|current head SHA.*headRefOid/s);
+  assert.doesNotMatch(auditSkill, /If \*\*empty\*\*.*receipt is still valid/s);
+  assert.match(auditProcess, /\*\*absent \/ stale\*\* → \*\*BLOCKER\*\*/);
 });
 
 test("missing receipt is a blocker even when every gate is nominally pass (receipt gate is first)", () => {

--- a/scripts/review-receipt.test.mjs
+++ b/scripts/review-receipt.test.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const reviewSkill = fs.readFileSync(path.join(repoRoot, "skills/review-change/SKILL.md"), "utf8");
+const reviewProcess = fs.readFileSync(path.join(repoRoot, "skills/review-change/references/REVIEW_PROCESS.md"), "utf8");
 const persistAndDecide = fs.readFileSync(path.join(repoRoot, "skills/review-change/references/PERSIST_AND_DECIDE.md"), "utf8");
 
 const CONTRACT = "v1";
@@ -65,6 +66,13 @@ test("final PR REVIEW-PASS requires a posted and re-read current receipt", () =>
   assert.match(reviewSkill, /must not recommend `\/audit-pr`/);
   assert.match(persistAndDecide, /receipt is a precondition of the report/);
   assert.match(persistAndDecide, /After posting.*confirm\s+the newest marker equals the reviewed head SHA/s);
+});
+
+test("review-change resolves and freezes the PR head before it can post a receipt", () => {
+  assert.match(reviewProcess, /git rev-parse HEAD/);
+  assert.match(persistAndDecide, /gh pr view --json number,headRefOid/);
+  assert.match(persistAndDecide, /headRefOid.*reviewed head SHA|reviewed head SHA.*headRefOid/s);
+  assert.match(persistAndDecide, /do not post.*re-run.*review-change|re-run.*review-change.*do not post/s);
 });
 
 test("receipt closeout precedes the fixed report block", () => {

--- a/skills/audit-pr/SKILL.md
+++ b/skills/audit-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: audit-pr
 user-invocable: true
-version: 4.3.0
+version: 4.3.1
 argument-hint: <pr-number> (optional — defaults to the current branch's PR)
 author: "Gabriel Trabanco <1969593+gtrabanco@users.noreply.github.com>"
 license: MIT
@@ -30,11 +30,10 @@ independently evaluates only the delivery gates below.
 ## Turn contract — verify before ending the turn
 
 ```
-✓ The review receipt was consumed: newest matching `review-change:pass` marker
-  fetched; absent → blocker routed to `/review-change`, stale → diff check:
-  empty-diff accepted with receipt acknowledged; non-empty-diff → blocker
-  routed to `/review-change`, current → its scope/axes/acceptance coverage/manual
-  checks acknowledged without re-review
+✓ The review receipt was consumed from one PR snapshot: `headRefOid` + newest
+  matching `review-change:pass` marker fetched together; absent or any SHA
+  mismatch → blocker routed to `/review-change`, current → its scope/axes/
+  acceptance coverage/manual checks acknowledged without re-review
 ✓ The verdict block was printed in the fixed format: `VERDICT: MERGE-READY | BLOCKED` with ranked, evidenced blockers
 ✓ The PR's FULL URL is printed in the verdict header (the user may be juggling
   several projects and agents without a CI monitor — the link in the chat is
@@ -89,7 +88,7 @@ CI. Default target is the current branch's PR; accept a PR number to target anot
 2. **The PR.** Identify it and read it in full (forge CLI per the project's
    Workflow conventions — examples use `gh`):
    ```sh
-   gh pr view <N> --json number,title,body,baseRefName,headRefName,isDraft,mergeable,mergeStateStatus,files,commits,statusCheckRollup,closingIssuesReferences
+   gh pr view <N> --json number,url,title,body,baseRefName,headRefName,headRefOid,isDraft,mergeable,mergeStateStatus,files,commits,statusCheckRollup,closingIssuesReferences
    ```
    If no PR number is given, resolve the current branch's PR
    (`gh pr view --json ...`). If none exists yet, audit the branch vs. the default
@@ -102,25 +101,23 @@ CI. Default target is the current branch's PR; accept a PR number to target anot
 ## Step 1 — Consume the review receipt (always, before any gate)
 
 The review evidence is the SHA-bound `REVIEW-PASS` receipt `review-change` posts
-on the PR — **never** a re-review composed here. Fetch the PR's comments and find
-the **newest** comment carrying the marker
+on the PR — **never** a re-review composed here. Fetch `headRefOid` and the PR's
+comments together, then find the **newest** comment carrying the marker
 `<!-- review-change:pass sha=<40-hex> contract=v1 -->`:
 
 ```sh
-gh pr view <N> --json comments
+gh pr view <N> --json headRefOid,comments
 ```
 
-- **current** — marker `sha` equals the PR's head SHA (from Step 0). Acknowledge
+- **current** — marker `sha` equals that snapshot's `headRefOid` (the current
+  head SHA). Acknowledge
   its scope/axes, acceptance coverage, invariant result, and manual checks as the
   review evidence, then evaluate the delivery gates below.
 - **absent** — no matching marker on the PR → **BLOCKER**: no review evidence at
   the head; route to `/review-change`.
-- **stale** — a marker exists but its `sha` predates the current head. Before
-  blocking, verify the diff: `git diff <marker-sha>..HEAD --stat`. If **empty**
-  (no meaningful changes landed between receipt and head), the receipt is still
-  valid — acknowledge its scope/axes and proceed to the delivery gates. If
-  **non-empty**, the receipt is void → **BLOCKER**: route to `/review-change`
-  for a re-review.
+- **stale** — a marker exists but its `sha` does not equal `headRefOid`. Any SHA
+  mismatch voids the receipt → **BLOCKER**: route to `/review-change` for a
+  re-review. Do not use a local `git diff` to override the PR-head comparison.
 
 Never compose, reconstruct, or "spot-check" the review from the diff to clear a
 missing/stale receipt — that is `review-change`'s turn, and re-litigating axes

--- a/skills/audit-pr/references/03_AUDIT_PROCESS.md
+++ b/skills/audit-pr/references/03_AUDIT_PROCESS.md
@@ -1,10 +1,12 @@
 ## Process
 
 1. **Gather** — Step 0: project contract, PR, SPEC + artifacts, CI status.
-2. **Consume the review receipt** — Step 1: fetch the PR's comments
-   (`gh pr view <N> --json comments`) and take the **newest** marker
+2. **Consume the review receipt** — Step 1: fetch the PR's `headRefOid` and
+   comments in one query (`gh pr view <N> --json headRefOid,comments`) and take
+   the **newest** marker
    `<!-- review-change:pass sha=<40-hex> contract=v1 -->`. Its `sha` must equal
-   the PR's current head SHA.
+   that query's `headRefOid` current head SHA. Any mismatch is stale; do not
+   use a local diff to preserve a receipt for a different PR head.
    - **current** → acknowledge scope/axes, acceptance coverage, invariant result,
      manual checks; continue to the gates.
    - **absent / stale** → **BLOCKER** (no review evidence at the head), routed to

--- a/skills/review-change/SKILL.md
+++ b/skills/review-change/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-change
 user-invocable: true
-version: 2.11.4
+version: 2.11.5
 argument-hint: <path-or-glob> [--adversarial N] [--synthesize]
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT

--- a/skills/review-change/references/PERSIST_AND_DECIDE.md
+++ b/skills/review-change/references/PERSIST_AND_DECIDE.md
@@ -34,6 +34,13 @@
    it). `REVIEW-FAIL` and `NEEDS-DECISION` post **no** passing receipt; continue
    to step 13 after recording that status.
 
+   The reviewed head SHA is the value frozen by `git rev-parse HEAD` in the
+   review process. Resolve the PR identity immediately before this action with
+   `gh pr view --json number,headRefOid`. No PR → take the documented pre-PR
+   path. With a PR, its `headRefOid` **must equal the reviewed head SHA** before
+   querying or posting comments. A mismatch means the candidate changed during
+   review: do not post a receipt and re-run `/review-change` at the PR head.
+
    For `REVIEW-PASS` with a PR, write the body below to a **temporary** Markdown
    file (e.g. `$TMPDIR/review-receipt.md`), then run
    `gh pr comment <N> --body-file <path>` — never inline `--body`, never commit

--- a/skills/review-change/references/REVIEW_PROCESS.md
+++ b/skills/review-change/references/REVIEW_PROCESS.md
@@ -6,6 +6,10 @@
    skip straight to that mode's fusion step (N findings tables pasted in, per
    the synthesis contract). Either way, everything from step 2 onward runs
    once, over the fused table.
+   **Freeze the reviewed commit before any pass:** after the clean/remote-current
+   check, run `git rev-parse HEAD` once and retain its 40-hex output as the
+   **reviewed head SHA**. The final PR receipt may be written only for that exact
+   commit; a PR whose head changes during the review requires a fresh review.
 2. **Frozen acceptance + SPEC drift check (structural).** Locate sibling
    `ACCEPTANCE.md`, recompute its blob, and require an exact match with the
    execution receipt before assessing the candidate. Missing/mismatch is a


### PR DESCRIPTION
## Summary
- freeze the reviewed SHA before `review-change` publishes its receipt
- resolve `headRefOid` with PR comments and reject every receipt SHA mismatch
- add regression coverage for both receipt boundaries

## Verification
- node --test scripts/*.test.mjs
- node scripts/check-skill-context.mjs --skill review-change --skill audit-pr
- npx skills add . --list
- git diff --check