### PR TITLE
fix(skills): focus loop review fold on target PR

### DIFF
--- a/CHANGELOG.es.md
+++ b/CHANGELOG.es.md
@@ -339,6 +339,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 #### `loop-review-fold`
 | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|
+| 1.0.3 | 2026-08-11 | parche | Elimina prosa redundante de composición y relaciones entre skills para centrar el punto de entrada en el loop del PR objetivo. |
 | 1.0.2 | 2026-08-10 | parche | Exige que las rutas no terminales de review/fold repitan todos los IDs de findings afectados en la recomendación de siguiente paso. |
 | 1.0.1 | 2026-08-09 | parche | Hace que el turno falle de forma cerrada ante casillas de contrato sin marcar y explicita los fallbacks de portabilidad para agentes que no usan Claude Code. |
 | 1.0.0 | 2026-08-09 | — | Nuevo conductor final acotado de review/corrección: reutiliza recibos al SHA exacto, alterna review de solo lectura y fold por lotes en contextos limpios solo para HEADs distintos, permite dos ciclos por defecto y se detiene al aprobar, requerir decisión, bloquearse, no progresar o agotar presupuesto. Nunca fusiona ni crea issues. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -338,6 +338,7 @@ How pinning actually works, verified against the `skills` CLI:
 #### `loop-review-fold`
 | Version | Date | Type | What changed |
 |---|---|---|---|
+| 1.0.3 | 2026-08-11 | patch | Removes redundant skill-composition and relationship prose, leaving the entry point focused on the target PR loop. |
 | 1.0.2 | 2026-08-10 | patch | Requires non-terminal review/fold routes to repeat every affected finding ID in the next-step recommendation. |
 | 1.0.1 | 2026-08-09 | patch | Makes the turn fail-closed on unchecked contract boxes and states the non-Claude portability fallbacks in the user-facing skill. |
 | 1.0.0 | 2026-08-09 | — | New bounded final review/correction conductor: reuses exact-SHA receipts, alternates fresh read-only review and batched fold contexts only for changed HEADs, defaults to two correction cycles, and stops on pass, decision, blocker, no progress, or budget exhaustion. Never merges or creates issues. |

--- a/skills/loop-review-fold/SKILL.md
+++ b/skills/loop-review-fold/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: loop-review-fold
 user-invocable: true
-version: 1.0.2
+version: 1.0.3
 argument-hint: <NN> | --fix <n> [--max-cycles N] [--adversarial N]
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
@@ -41,46 +41,26 @@ Any unchecked box means the turn is not done.
 - `--adversarial N` — forwards the final-review mode to `review-change`.
 
 Invalid/missing unit, no open PR, dirty/unpushed branch, or non-positive budget
-stops before review with the exact evidence and recovery command.
+stops as `BLOCKED` with the recovery command.
 
-## Progressive loading
+## Process
 
-Read exactly, in order:
-
-1. [loop policy and terminal states](references/LOOP_POLICY.md)
-2. [review/fold process](references/LOOP_PROCESS.md)
-3. [portability and model routing](references/PORTABILITY.md) only when a named
-   fresh-context/tier primitive is unavailable.
-
-Consume the internal [verification contract](<../verification-contract/SKILL.md>).
-Compose `review-change` and `fold-findings`; never copy their finder,
-classification, ledger, or correction checklists into this skill.
+Read [loop policy and terminal states](references/LOOP_POLICY.md), then the
+[review/fold process](references/LOOP_PROCESS.md). Read
+[portability and model routing](references/PORTABILITY.md) only when a named
+fresh-context/tier primitive is unavailable.
 
 ## Portability (agents other than Claude Code)
 
-- Without a slash-command menu, open this `SKILL.md` in a fresh conversation and
-  follow it literally.
 - Without native fresh contexts, subagents, or tier controls, use the
   `PORTABILITY.md` fallbacks; never claim a context-clean review after the same
   context authored a correction.
 - Without `/loop`, re-invoke this skill manually and follow the terminal
-  `→ Next:` block. Keep the same remote-HEAD, receipt, finding, and cycle
-  counters.
-
-## Relationship to other skills
-
-- Starts after `execute-phase` opens a PR.
-- `review-change` owns immutable-candidate findings and the exact-SHA receipt.
-- `fold-findings` owns all mutation and per-finding ledger transitions.
-- `audit-pr` is the next gate only after terminal `PASS`.
-- `ship-roadmap` may use this as its REVIEW stage; it does not change merge
-  authority (`--fullauto` AUDIT wrapper only).
+  `→ Next:` block.
 
 ## Done when
 
-- One terminal state is reached with HEAD/receipt/findings/cycle evidence.
-- PASS has a current exact-SHA review receipt and zero open fix-now rows.
-- Every non-PASS state names a deterministic resume or decision path.
+Return the terminal state required by `LOOP_POLICY.md`.
 
 ```text
 → Next: (terminal-dependent; use LOOP_POLICY.md's exact block and repeat every open finding ID joined with ` + `)


### PR DESCRIPTION
## Summary
- remove redundant skill-composition and relationship prose from loop-review-fold
- keep the entrypoint focused on the target PR review/fold loop
- update the patch version and bilingual changelogs

## Validation
- node scripts/bounded-delivery-loops.test.mjs
- node scripts/next-recommendations.test.mjs
- node scripts/check-skill-context.mjs