### PR TITLE
fix(schema): normalize rendered envelope verdicts into canonical enums

### DIFF
--- a/CHANGELOG.es.md
+++ b/CHANGELOG.es.md
@@ -573,6 +573,17 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 
 ## Registro cronológico (más reciente primero)
 
+- **2026-08-20 — schema 2.2.0: ruido de representación normalizado a enums canónicos.**
+  `parseEnvelope`/`validateEnvelope` ahora pliegan las grafías de estado que el
+  agente copia de la salida de las herramientas sobre los enums canónicos del
+  sobre antes de validar — conclusiones de GitHub (`failing`/`failed` → `red`,
+  `success`/`passing` → `green`, `queued`/`in_progress` → `pending`,
+  `skipped`/`neutral` → `none`), veredicto de PR (`CLOSED` → `none`), el gate
+  de verificación (`failed` → `red`, `not_run` → `not-run`), cualquier
+  capitalización y las formas en minúscula de `state`. El sobre devuelto
+  siempre lleva valores canónicos; un valor sin mapeo se sigue rechazando.
+  Corrige los drives de workflow que fallaban (p. ej. `pr.ci: "failing"` era
+  rechazado). Empaquetado en `packages/agentic-workflow-schema` → `2.2.0`.
 - **2026-08-14 — simplificar el loop review/fold.** `loop-review-fold` 2.0.0
   ahora elige `review-change` o `fold-findings` según la evidencia persistida y
   lleva los hallazgos no resueltos a `triage-issue --prioritize-now`; el trabajo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -572,6 +572,17 @@ How pinning actually works, verified against the `skills` CLI:
 
 ## Release log (chronological, newest first)
 
+- **2026-08-20 — schema 2.2.0: render noise normalized to canonical enums.**
+  `parseEnvelope`/`validateEnvelope` now fold real-world state spellings the
+  agent copies from tool output onto the canonical envelope vocabulary before
+  checking — GitHub check conclusions (`failing`/`failed` → `red`,
+  `success`/`passing` → `green`, `queued`/`in_progress` → `pending`,
+  `skipped`/`neutral` → `none`), PR verdict (`CLOSED` → `none`), the project
+  gate (`failed` → `red`, `not_run` → `not-run`), any capitalization, and the
+  lowercase forms of `state`. The returned envelope always carries canonical
+  values; a spelling with no mapping is still rejected. Fixes hard-failed
+  workflow drives (e.g. `pr.ci: "failing"` was rejected by the strict enum).
+  Packaged in `packages/agentic-workflow-schema` → `2.2.0`.
 - **2026-08-14 — simplify the review/fold loop.** `loop-review-fold` 2.0.0
   now selects `review-change` or `fold-findings` from persisted evidence and
   sends unresolved findings through `triage-issue --prioritize-now`; oversized

--- a/packages/agentic-workflow-schema/README.es.md
+++ b/packages/agentic-workflow-schema/README.es.md
@@ -64,6 +64,21 @@ funciona:
 import schema from "@gtrabanco/agentic-workflow-schema/envelope.schema.json" with { type: "json" };
 ```
 
+## Los veredictos renderizados se normalizan
+
+Los agentes copian el estado real desde la salida de las herramientas, así
+que el parser mapea las grafías comunes a los enums canónicos **antes** de
+validar, y el sobre devuelto siempre lleva valores canónicos: conclusiones
+de checks de GitHub (`failing` / `failed` / `failure` → `red`;
+`success` / `passing` → `green`; `queued` / `running` / `in_progress` →
+`pending`; `skipped` / `neutral` / `cancelled` → `none`), veredicto de PR
+(`CLOSED` → `none`), el gate de verificación (`failed` → `red`, `not_run` →
+`not-run`), y también cualquier capitalización y las grafías en minúscula
+de los 11 valores de `state`. Los enums cerrados de abajo siguen siendo **el
+contrato canónico** del sobre devuelto; un valor sin mapeo se sigue
+rechazando — la normalización repara el ruido de representación, nunca
+inventa hechos ni debilita el vocabulario.
+
 ## El sobre, campo por campo
 
 Cada clave de nivel superior está **siempre presente** (`required` en el

--- a/packages/agentic-workflow-schema/README.md
+++ b/packages/agentic-workflow-schema/README.md
@@ -61,6 +61,20 @@ On Node 20.10+/22, the newer import-attributes form also works:
 import schema from "@gtrabanco/agentic-workflow-schema/envelope.schema.json" with { type: "json" };
 ```
 
+## Rendered verdicts are normalized
+
+Agents copy real-world state words from tool output, so the parser maps
+common renderings onto the canonical enums **before** checking, and the
+parsed envelope always carries canonical values: GitHub check conclusions
+(`failing` / `failed` / `failure` → `red`; `success` / `passing` → `green`;
+`queued` / `running` / `in_progress` → `pending`; `skipped` / `neutral` /
+`cancelled` → `none`), PR verdict (`CLOSED` → `none`), the project gate
+(`failed` → `red`, `not_run` → `not-run`), plus any capitalization and the
+lowercase spellings of the 11 `state` values. The closed enums below remain
+**the canonical contract** of the returned envelope; a spelling with no
+mapping is still rejected — normalization repairs render noise, it never
+invents facts or weakens the vocabulary.
+
 ## The envelope, field by field
 
 Every top-level key is **always present** (`required` in the JSON Schema) —

--- a/packages/agentic-workflow-schema/package.json
+++ b/packages/agentic-workflow-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gtrabanco/agentic-workflow-schema",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Types, JSON Schema, and parser/validator for the agentic-workflow machine envelope — the fixed JSON block a driven agent turn ends with (workflow-status always; other skills under the driver-injected snippet), for programmatic orchestration.",
   "keywords": [
     "agentic-workflow",

--- a/packages/agentic-workflow-schema/src/index.ts
+++ b/packages/agentic-workflow-schema/src/index.ts
@@ -212,6 +212,147 @@ const BLOCKER_KINDS = [
 const BLOCKER_SCOPES = ["unit", "run"];
 const FIX_NOW_SEVERITIES = ["high", "med", "low"];
 
+// ---------------------------------------------------------------------------
+// Enum normalization — rendered real-world verdicts → canonical vocabulary
+// ---------------------------------------------------------------------------
+
+const CI_STATE_ALIASES: Record<string, CiState> = {
+  failing: "red",
+  failed: "red",
+  failure: "red",
+  fail: "red",
+  timed_out: "red",
+  "timed-out": "red",
+  action_required: "red",
+  "action-required": "red",
+  startup_failure: "red",
+  "startup-failure": "red",
+  faulted: "red",
+  passing: "green",
+  passed: "green",
+  pass: "green",
+  success: "green",
+  succeeded: "green",
+  successful: "green",
+  neutral: "none",
+  cancelled: "none",
+  canceled: "none",
+  skipped: "none",
+  stale: "none",
+  queued: "pending",
+  in_progress: "pending",
+  "in-progress": "pending",
+  running: "pending",
+  waiting: "pending",
+};
+
+const VERIFICATION_STATE_ALIASES: Record<string, VerificationState> = {
+  failing: "red",
+  failed: "red",
+  failure: "red",
+  fail: "red",
+  passing: "green",
+  passed: "green",
+  pass: "green",
+  success: "green",
+  succeeded: "green",
+  successful: "green",
+  not_run: "not-run",
+  "not-run": "not-run",
+  skipped: "not-run",
+};
+
+const PR_STATE_ALIASES: Record<string, PrState> = {
+  closed: "none",
+};
+
+/**
+ * Map one scalar onto its canonical enum spelling: case-insensitive canonical
+ * match first, then a strict alias table. Unknown values are returned
+ * untouched so validation below still rejects them — a sloppy spelling is
+ * corrected, an unrecognized one is never silently accepted.
+ */
+function canonicalEnumValue<T extends string>(
+  value: unknown,
+  canonical: readonly T[],
+  aliases: Record<string, T> = {}
+): unknown {
+  if (typeof value !== "string") return value;
+  const folded = value.trim().toLowerCase();
+  const exact = canonical.find((entry) => entry.toLowerCase() === folded);
+  return (exact ?? aliases[folded]) ?? value;
+}
+
+/**
+ * Render the real-world spellings a model copies from tool output (GitHub
+ * check conclusions like `failing`, `timed_out`, `queued`; verdict words like
+ * `success`, `failed`, `closed`; any capitalization) onto the canonical
+ * envelope vocabulary, on a shallow copy of the input. The canonical types
+ * (`CiState`, `PrState`, ...) are unchanged — this only makes the parser
+ * tolerant of how those facts are spelled on the wire while still returning a
+ * canonical envelope.
+ */
+function normalizeEnvelopeEnums(value: Record<string, unknown>): Record<string, unknown> {
+  const normalized: Record<string, unknown> = { ...value };
+  normalized.state = canonicalEnumValue(value.state, ENVELOPE_STATES as readonly string[]);
+  if (isObj(value.unit)) {
+    normalized.unit = {
+      ...value.unit,
+      type: canonicalEnumValue(value.unit.type, UNIT_TYPES),
+    };
+  }
+  if (isObj(value.pr)) {
+    normalized.pr = {
+      ...value.pr,
+      state: canonicalEnumValue(value.pr.state, PR_STATES, PR_STATE_ALIASES),
+      ci: canonicalEnumValue(value.pr.ci, CI_STATES, CI_STATE_ALIASES),
+    };
+  }
+  if (isObj(value.gates)) {
+    normalized.gates = {
+      ...value.gates,
+      verification: canonicalEnumValue(
+        value.gates.verification,
+        VERIFICATION_STATES,
+        VERIFICATION_STATE_ALIASES
+      ),
+    };
+  }
+  if (isObj(value.next)) {
+    normalized.next = {
+      ...value.next,
+      tier: canonicalEnumValue(value.next.tier, ["strong", "cheap"]),
+    };
+  }
+  if (Array.isArray(value.blockers)) {
+    normalized.blockers = value.blockers.map((blocker) =>
+      isObj(blocker)
+        ? {
+            ...blocker,
+            kind: canonicalEnumValue(blocker.kind, BLOCKER_KINDS),
+            scope: canonicalEnumValue(blocker.scope, BLOCKER_SCOPES),
+          }
+        : blocker
+    );
+  }
+  const findings = value.findings;
+  if (isObj(findings) && Array.isArray(findings.fix_now)) {
+    normalized.findings = {
+      ...findings,
+      fix_now: (findings.fix_now as unknown[]).map((finding) =>
+        isObj(finding)
+          ? {
+              ...finding,
+              severity: canonicalEnumValue(finding.severity, FIX_NOW_SEVERITIES),
+              suggested_tier: canonicalEnumValue(finding.suggested_tier, ["strong", "cheap"]),
+            }
+          : finding
+      ),
+    };
+  }
+  return normalized;
+}
+
 const REQUIRED_KEYS = [
   "skill",
   "state",
@@ -230,10 +371,18 @@ const REQUIRED_KEYS = [
 
 /**
  * Structural validation of a parsed value against the envelope contract.
+ *
+ * Rendered enum spellings are normalized first (see `normalizeEnvelopeEnums`:
+ * `pr.ci: "failing"` validates as the canonical `red`, `SUCCESS` as `green`,
+ * `CLOSED` as `none`), so the returned envelope always carries canonical
+ * values. Unknown spellings are still rejected — normalization corrects
+ * recognizable render noise, it never invents facts.
+ *
  * Checks required keys, the state enum, and the shape of the routing-critical
  * fields (an orchestrator routes on these; `detail` is intentionally opaque).
  */
-export function validateEnvelope(value: unknown): ValidationResult {
+export function validateEnvelope(rawValue: unknown): ValidationResult {
+  const value = isObj(rawValue) ? normalizeEnvelopeEnums(rawValue) : rawValue;
   const errors: string[] = [];
   if (!isObj(value)) {
     return { ok: false, errors: ["envelope is not a JSON object"] };

--- a/packages/agentic-workflow-schema/test/index.test.mjs
+++ b/packages/agentic-workflow-schema/test/index.test.mjs
@@ -154,7 +154,7 @@ test("extracts the last block across CRLF line endings", () => {
 
 test("rejects out-of-enum values throughout the envelope", () => {
   const cases = [
-    { ...VALID, pr: { ...VALID.pr, state: "closed" } },
+    { ...VALID, pr: { ...VALID.pr, state: "forged" } },
     { ...VALID, pr: { ...VALID.pr, ci: "purple" } },
     { ...VALID, gates: { ...VALID.gates, verification: "yellow" } },
     { ...VALID, blockers: [{ kind: "planet", id: "x", scope: "unit", detail: "d" }] },
@@ -165,6 +165,54 @@ test("rejects out-of-enum values throughout the envelope", () => {
     const result = validateEnvelope(bad);
     assert.equal(result.ok, false, `expected rejection for ${JSON.stringify(bad)}`);
   }
+});
+
+test("normalizes rendered CI verdicts into the canonical pr.ci vocabulary", () => {
+  const rendered = [
+    ["failing", "red"],
+    ["failure", "red"],
+    ["action_required", "red"],
+    ["passing", "green"],
+    ["SUCCESS", "green"],
+    ["queued", "pending"],
+    ["in_progress", "pending"],
+    ["skipped", "none"],
+  ];
+  for (const [spelling, canonical] of rendered) {
+    const result = parseEnvelope(wrap({ ...VALID, pr: { ...VALID.pr, ci: spelling } }));
+    assert.equal(result.ok, true, spelling);
+    assert.equal(result.envelope.pr.ci, canonical, spelling);
+  }
+});
+
+test("parseEnvelope returns the canonical envelope for state, pr.state and verification", () => {
+  const result = parseEnvelope(
+    wrap({
+      ...VALID,
+      state: "blocked",
+      pr: { ...VALID.pr, state: "CLOSED", ci: "failed" },
+      gates: { ...VALID.gates, verification: "failed" },
+    })
+  );
+  assert.equal(result.ok, true);
+  assert.equal(result.envelope.state, "BLOCKED");
+  assert.equal(result.envelope.pr.state, "none");
+  assert.equal(result.envelope.pr.ci, "red");
+  assert.equal(result.envelope.gates.verification, "red");
+});
+
+test("validateEnvelope normalizes too and never mutates its input", () => {
+  const input = { ...VALID, pr: { ...VALID.pr, ci: "failing" } };
+  const result = validateEnvelope(input);
+  assert.equal(result.ok, true);
+  assert.equal(result.envelope.pr.ci, "red");
+  assert.equal(input.pr.ci, "failing", "caller object must be left untouched");
+});
+
+test("still rejects a ci spelling with no canonical mapping", () => {
+  const result = validateEnvelope({ ...VALID, pr: { ...VALID.pr, ci: "flaky" } });
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((e) => e.includes("pr.ci")));
 });
 
 test("accepts every documented enum value (no false positives)", () => {


### PR DESCRIPTION
## Root cause

`@gtrabanco/agentic-workflow-schema` rejected real-world state spellings that a
workflow-skill agent copies from tool output. In a driven Pi session running
`workflow-status`, the agent rendered the actual GitHub check state as
`pr.ci: "failing"`; the strict enum (`green|red|pending|none|null`) rejected it
and the whole workflow drive hard-failed at the trust boundary:

```
No valid agentic-workflow machine envelope was found: pr.ci must be one of green|red|pending|none or null (got: failing)
```

This package is the authority for the envelope contract, so the normalization
belongs here, not in each orchestrator.

## Change

- `parseEnvelope` / `validateEnvelope` now fold rendered verdicts onto the
  canonical vocabulary **before** checking, and return a canonical envelope:
  - `pr.ci`: failing/failed/failure→red, success/passing→green,
    queued/running/in_progress→pending, skipped/neutral/cancelled→none
  - `pr.state`: `CLOSED`→none
  - `gates.verification`: failed→red, not_run→not-run
  - any capitalization and the lowercased 11 `state` values
- A spelling with no mapping is **still rejected** — normalization repairs
  render noise, it never invents facts or weakens the contract (types stay
  the same).
- Version → **2.2.0**, EN/ES README note + CHANGELOG entries, 22/22 tests.

## Verification

`bun run test` in the package (22 pass), and the consumer
(agentic-workflow-loop) gates green against this build (231 tests,
lint/typecheck/smoke); its `packages/protocol` now delegates parsing to this
package and pins 2.2.0.

Merging publishes @gtrabanco/agentic-workflow-schema@2.2.0 to npm via
`publish-schema.yml` (Trusted Publishing).