### PR TITLE
fix(distribution): install orchestration turn contract

### DIFF
--- a/CHANGELOG.es.md
+++ b/CHANGELOG.es.md
@@ -482,6 +482,7 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 
 | Skill | Versión | Fecha | Tipo | Qué cambió |
 |---|---|---|---|---|
+| `orchestration-envelope` | 2.0.2 | 2026-08-22 | parche | Restaura la distribución mediante el `skills add` predeterminado al retirar los metadatos erróneos de exclusión del descubrimiento, para que los consumidores instalen el contrato de turno canónico requerido por `design-feature`, `execute-phase` y `review-change`. |
 | `orchestration-envelope` | 2.0.1 | 2026-08-21 | parche | Aclara que `ship-roadmap` es un conductor con banner nativo fuera de los perfiles de resultado máquina de workers/sensors, y alinea la guía de perfiles y drivers. |
 | `orchestration-envelope` | 2.0.0 | 2026-08-21 | mayor | **Contrato de driver incompatible:** sustituye el prompt duplicado del envelope completo por perfiles de salida del paquete, SkillOutcome v1 compacto, snapshots deterministas, compatibilidad nombrada y una reparación genérica acotada de resultado máquina. Ver `docs/workflow/MIGRATION.es.md`. |
 | `orchestration-envelope` | 1.5.1 | 2026-08-09 | parche | Sin cambio de comportamiento: comprime emisión, reglas de campos, repair loop, sincronización de paquete, relaciones y NRS preservando esquema y protocolo del driver. |
@@ -577,6 +578,12 @@ Cómo funciona el pinning realmente, **verificado** contra el CLI `skills`:
 ---
 
 ## Registro cronológico (más reciente primero)
+
+- **2026-08-22 — restaurar el contrato de turno canónico.**
+  `orchestration-envelope` 2.0.2 vuelve a ser descubrible mediante la ruta
+  predeterminada de `skills add`, para que los entrypoints instalados del
+  workflow puedan cargar su `TURN_CONTRACT.md` obligatorio mientras el contrato
+  permanece fuera del menú invocable por el usuario.
 
 - **2026-08-21 — contratos máquina híbridos.** El paquete de esquema 3.0.0
   separa el Envelope v2 estable de `workflow-status`, el SkillOutcome v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -481,6 +481,7 @@ How pinning actually works, verified against the `skills` CLI:
 
 | Skill | Version | Date | Type | What changed |
 |---|---|---|---|---|
+| `orchestration-envelope` | 2.0.2 | 2026-08-22 | patch | Restores default `skills add` distribution by removing erroneous discovery-exclusion metadata, so consumers install the canonical turn contract required by `design-feature`, `execute-phase`, and `review-change`. |
 | `orchestration-envelope` | 2.0.1 | 2026-08-21 | patch | Clarifies that `ship-roadmap` is a native-banner conductor outside the worker/sensor machine-result profiles, and aligns the profile and driver guidance. |
 | `orchestration-envelope` | 2.0.0 | 2026-08-21 | major | **Breaking driver contract:** replaces the duplicated full-envelope prompt with package-owned output profiles, compact SkillOutcome v1, deterministic snapshots, named compatibility, and one bounded generic machine-result repair. See `docs/workflow/MIGRATION.md`. |
 | `orchestration-envelope` | 1.5.1 | 2026-08-09 | patch | No behavior change: compresses emission, field-rule, repair-loop, package-sync, relationship, and NRS prose while preserving the schema and driver protocol. |
@@ -576,6 +577,11 @@ How pinning actually works, verified against the `skills` CLI:
 ---
 
 ## Release log (chronological, newest first)
+
+- **2026-08-22 — restore the canonical turn contract.**
+  `orchestration-envelope` 2.0.2 is discoverable again through the default
+  `skills add` path, so installed workflow entrypoints can load its required
+  `TURN_CONTRACT.md` while the contract remains outside the user-invocable menu.
 
 - **2026-08-21 — hybrid machine contracts.** The schema package 3.0.0
   separates the stable `workflow-status` Envelope v2, compact SkillOutcome v1,

--- a/scripts/bounded-delivery-loops.test.mjs
+++ b/scripts/bounded-delivery-loops.test.mjs
@@ -82,12 +82,18 @@ assert.equal(fs.existsSync(path.join(root, "skills", "plan-feature-interview")),
   "retired plan-feature-interview must remain absent from the source tree");
 assert.match(read("skills/bump-skill/SKILL.md"), /^user-invocable: false$/m);
 assert.match(read("skills/bump-skill/SKILL.md"), /^  internal: true$/m);
-for (const requiredDependency of ["loop-review-fold", "phase-contract", "planning-preflight", "verification-contract"]) {
+for (const requiredDependency of [
+  "loop-review-fold",
+  "orchestration-envelope",
+  "phase-contract",
+  "planning-preflight",
+  "verification-contract",
+]) {
   assert.ok(pluginSkills.includes(requiredDependency), `${requiredDependency} must be distributed by plugin.json`);
 }
-for (const distributedDependency of ["phase-contract", "planning-preflight", "verification-contract"]) {
-  assert.doesNotMatch(read(`skills/${distributedDependency}/SKILL.md`), /^metadata:\n  internal: true$/m,
-    `${distributedDependency} must remain discoverable by the skills CLI`);
+for (const distributedSkill of pluginSkills) {
+  assert.doesNotMatch(read(`skills/${distributedSkill}/SKILL.md`), /^metadata:\n  internal: true$/m,
+    `${distributedSkill} must remain discoverable by the skills CLI`);
 }
 assert.deepEqual(pluginSkills, [...pluginSkills].sort(), "plugin skills must stay alphabetical");
 

--- a/skills/orchestration-envelope/SKILL.md
+++ b/skills/orchestration-envelope/SKILL.md
@@ -1,9 +1,7 @@
 ---
 name: orchestration-envelope
 user-invocable: false
-version: 2.0.1
-metadata:
-  internal: true
+version: 2.0.2
 author: "Gabriel Trabanco <gtrabanco@users.noreply.github.com>"
 license: MIT
 description: >


### PR DESCRIPTION
## Summary

- restore `orchestration-envelope` discovery in the default `skills add` path
- keep `bump-skill` excluded as the repository-only maintenance skill
- protect every `plugin.json`-distributed skill from accidental `metadata.internal: true`
- bump `orchestration-envelope` to 2.0.2 and synchronize both changelogs

## Root cause

`orchestration-envelope` was registered for distribution but also carried
`metadata.internal: true`. The skills CLI therefore omitted it, so installed
entrypoints such as `design-feature` could not load the canonical
`.claude/skills/orchestration-envelope/references/TURN_CONTRACT.md`.

## Verification

- `node --test scripts/*.test.mjs` — 49/49 pass
- `node scripts/check-skill-context.mjs` — 35 skills pass
- `npx skills add . --list` — `orchestration-envelope` present; `bump-skill` absent
- clean copied install — `design-feature` and `orchestration-envelope/references/TURN_CONTRACT.md` present
- `git diff --check`
