### PR TITLE
fix(pi-agentic-workflow): re-sync fold-findings bundle drifted by the F1–F3 fold (#188)

### DIFF
--- a/packages/pi-agentic-workflow/skills/fold-findings/SKILL.md
+++ b/packages/pi-agentic-workflow/skills/fold-findings/SKILL.md
@@ -95,7 +95,7 @@ Omit `· Replan: r` when `r = 0` (preserves the existing three-field format).
 Then print the REPAIR-RECEIPT as the ABSOLUTE-last output, together with the
 branching `→ Next:` block below. The receipt is immutable once printed; a
 later fold prints a new receipt (append-only output history — no ledger row,
-no schema field). Five fields, always present:
+no schema field). Six fields, always present:
 
 ```
 ## REPAIR-RECEIPT
@@ -180,6 +180,7 @@ decision to skip.
 | Batch state | Branch | `→ Next:` (consumer) |
 |---|---|---|
 | freeze-batch (≥ 1 replan-class row) | `REPLAN-ROUTE` | plan-fix/execute-phase on this unit after the user confirms the replan |
+| `all-repair-in-place` + docs-only + no folded row severity `high` + prior consumer skip decision | `RE-REVIEW-SKIPPED` | skip — consumer has explicitly decided to skip the re-review |
 | `all-repair-in-place` + docs-only + no folded row severity `high` | `RE-REVIEW-OPTIONAL` | `/review-change` (default, delta mode) — or the consumer's recorded skip decision |
 | empty batch (class `none`) | `RE-REVIEW-OPTIONAL` | `/review-change` by default — safe: the head is unchanged |
 | anything else (behavioral surface or any folded row `high`) | `RE-REVIEW-REQUIRED (delta)` | `/review-change` — delta mode mandatory default |

--- a/packages/pi-agentic-workflow/skills/fold-findings/references/FOLD_PROCESS.md
+++ b/packages/pi-agentic-workflow/skills/fold-findings/references/FOLD_PROCESS.md
@@ -60,3 +60,19 @@
 9. **Replan.** If the smallest correct group exceeds a reviewable correction,
    emit `REPLAN` with proposed phases appended to the same unit. After user
    confirmation, `/execute-phase <unit>` completes them and ticks the rows.
+
+## REPAIR-RECEIPT — fixed printed block (verbatim copy)
+
+Printed after the per-finding table and tally, as part of the ABSOLUTE-last
+output together with the branching `→ Next:` block. Six fields, always
+present:
+
+```text
+## REPAIR-RECEIPT
+- Repaired: <F-ids with (VF-<n>) refs, joined ` + `, or `none`>
+- Refuted/open: <F-ids joined ` + `, or `none`>
+- Gate: <command> → exit <n> at head <40-hex sha> · n/a when nothing was folded
+- Batch class: <all-repair-in-place | frozen (replan present) | none>
+- Fold diff: <shortstat from a real `git diff` run> · none when nothing was folded
+- Branch: <RE-REVIEW-REQUIRED (delta) | RE-REVIEW-OPTIONAL | RE-REVIEW-SKIPPED | REPLAN-ROUTE>
+```


### PR DESCRIPTION
# Root cause

PR #188's P4 qualification commit re-bundled the Pi package (`e77c6f60`), but the F1+F2+F3 fold (`596a9f25`) edited `skills/fold-findings/` **after** that re-bundle and no re-sync followed. CLAUDE.md's verification rule — *any change to a `skills/<name>/SKILL.md` is re-bundled into the package, same PR, always* — was violated, and the committed mirror shipped stale.

The publish workflow's test gate caught it exactly as designed (the skill-parity suite is written red-first for this):

```
not ok 123 - AC2: every bundled file is byte-identical to its skills/ source
  fold-findings/SKILL.md: bundle bytes drifted from skills/ source
  https://github.com/gtrabanco/agentic-workflow/actions/runs/34169083006/job/101885793620
```

# Fix

Re-ran the bundler (`bun run bundle:skills` in `packages/pi-agentic-workflow`). It syncs the two drifted files and nothing else — the diff is byte-identical to what the F1–F3 fold added to the source tree:

| File | Synced content |
|---|---|
| `SKILL.md` | F1: `Five fields` → `Six fields` in the REPAIR-RECEIPT contract · F2: the `RE-REVIEW-SKIPPED` branch row |
| `references/FOLD_PROCESS.md` | F3: the verbatim REPAIR-RECEIPT fixed block |

`bump-skill` (internal) stays correctly excluded; no other skill drifted.

# Verification

- `bun run test` in `packages/pi-agentic-workflow`: **140/140 pass**, including the previously failing `AC2: every bundled file is byte-identical to its skills/ source`.
- No version bump needed: 0.7.0 was never published (registry at 0.6.0), so merging this publishes **0.7.0 with the complete `fold-findings` 1.4.0 bundle** — the CHANGELOG 0.7.0 row already describes it.

# Note (follow-up, not in scope)

The drift guard only runs on push to `main` (publish workflow, `paths: packages/pi-agentic-workflow/**`). PR #188 touched `skills/` in its final commits, so no PR-level check saw the bundle drift before merge. A cheap prevention: run `skill-parity` in a PR workflow when `skills/**` or the package mirror changes. Left as a separate decision to keep this PR a one-command re-sync.